### PR TITLE
feat: Phase 1 Core Engagement Loop (Closes #2)

### DIFF
--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -1,29 +1,126 @@
 extends Node
 
 # Singleton to manage game state
+
+signal pet_stat_changed(pet_id: int, stat_name: String, new_value: int)
+signal coins_changed(new_amount: int)
+signal pet_mood_changed(pet_id: int, new_mood: String)
+
 var pets = {}
+var coins: int = 50
 var current_location = "hub"
 
+var _next_pet_id: int = 1
+var _decay_timer: float = 0.0
+const DECAY_INTERVAL: float = 60.0
+
 func _ready():
-	# Initialize game
 	pass
 
-func add_pet(pet_name: String, pet_type: String):
-	var pet_id = randi() % 10000
+func _process(delta: float):
+	_decay_timer += delta
+	if _decay_timer >= DECAY_INTERVAL:
+		_decay_timer -= DECAY_INTERVAL
+		_tick_stat_decay()
+
+func _tick_stat_decay():
+	for pet_id in pets.keys():
+		var pet = pets[pet_id]
+		if pet["health"] <= 0:
+			continue  # resting pets don't decay
+
+		# Base decay: hunger -2, happiness -1 (floor at 10)
+		var hunger_decay = -2
+		var happiness_decay = -1
+
+		# Low hunger (<20) accelerates happiness decay
+		if pet["hunger"] < 20:
+			happiness_decay -= 1
+
+		# Low happiness (<20) causes slow health decay
+		if pet["happiness"] < 20:
+			modify_stat(pet_id, "health", -1)
+
+		modify_stat(pet_id, "hunger", hunger_decay)
+		modify_stat(pet_id, "happiness", happiness_decay)
+
+func add_pet(pet_name: String, pet_type: String) -> int:
+	var pet_id = _next_pet_id
+	_next_pet_id += 1
 	pets[pet_id] = {
 		"name": pet_name,
 		"type": pet_type,
 		"health": 100,
 		"happiness": 100,
+		"hunger": 50,
+		"energy": 100,
 		"location": "hub"
 	}
 	return pet_id
 
-func heal_pet(pet_id: int, heal_amount: int = 50):
-	if pet_id in pets:
-		pets[pet_id]["health"] = min(100, pets[pet_id]["health"] + heal_amount)
-		return true
-	return false
+func modify_stat(pet_id: int, stat_name: String, amount: int):
+	if pet_id not in pets:
+		return
+	if stat_name not in ["health", "happiness", "hunger", "energy"]:
+		return
+
+	var old_value = pets[pet_id][stat_name]
+	var floor_value = 10 if stat_name in ["hunger", "happiness"] else 0
+	var new_value = clampi(old_value + amount, floor_value, 100)
+	pets[pet_id][stat_name] = new_value
+
+	if new_value != old_value:
+		pet_stat_changed.emit(pet_id, stat_name, new_value)
+
+	# Check for mood change
+	var new_mood = get_pet_mood(pet_id)
+	pet_mood_changed.emit(pet_id, new_mood)
+
+	# Health at 0 = resting state
+	if stat_name == "health" and new_value <= 0:
+		pets[pet_id]["health"] = 0
+
+func modify_coins(amount: int):
+	coins = max(0, coins + amount)
+	coins_changed.emit(coins)
+
+func heal_pet(pet_id: int, heal_amount: int = 30) -> bool:
+	if pet_id not in pets:
+		return false
+	if coins < 10:
+		return false
+	modify_coins(-10)
+	modify_stat(pet_id, "health", heal_amount)
+	return true
+
+func get_pet_mood(pet_id: int) -> String:
+	if pet_id not in pets:
+		return "content"
+	var pet = pets[pet_id]
+	if pet["health"] <= 0:
+		return "resting"
+	if pet["hunger"] < 20:
+		return "hungry"
+	if pet["happiness"] >= 70:
+		return "happy"
+	if pet["happiness"] >= 40:
+		return "content"
+	return "sad"
+
+func get_mood_emoji(pet_id: int) -> String:
+	match get_pet_mood(pet_id):
+		"happy":
+			return "^_^"
+		"content":
+			return "-_-"
+		"sad":
+			return "T_T"
+		"hungry":
+			return ">_<"
+		"resting":
+			return "zzZ"
+		_:
+			return "-_-"
 
 func update_pet_location(pet_id: int, location: String):
 	if pet_id in pets:

--- a/scripts/Island.gd
+++ b/scripts/Island.gd
@@ -1,23 +1,32 @@
 extends Node3D
 
-# Island scene - Keyboard only controls
+# Island scene — pet interactions with keyboard controls
 var game_manager
-var pets_in_scene = []
+var pets_in_scene: Array = []
+var selected_pet_index: int = 0
+var pet_ids: Array = []
+
+var _feedback_label: Label
+var _stats_label: Label
+var _coins_label: Label
+var _pet_list_label: Label
+var _feedback_timer: float = 0.0
 
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 
-	# Create island environment
 	_create_island_environment()
-
-	# Spawn all pets on the island
 	_spawn_all_pets()
-
-	# Create UI
 	_create_ui()
 
+	game_manager.pet_stat_changed.connect(_on_stat_changed)
+	game_manager.coins_changed.connect(_on_coins_changed)
+
+	if pet_ids.size() > 0:
+		_highlight_selected()
+		_update_stats_display()
+
 func _create_island_environment():
-	# Ground
 	var ground = MeshInstance3D.new()
 	var plane_mesh = PlaneMesh.new()
 	plane_mesh.size = Vector2(30, 30)
@@ -25,17 +34,15 @@ func _create_island_environment():
 	ground.position.y = -1
 
 	var ground_material = StandardMaterial3D.new()
-	ground_material.albedo_color = Color(0.2, 0.6, 0.2)  # Green island
+	ground_material.albedo_color = Color(0.2, 0.6, 0.2)
 	ground.material_override = ground_material
 	add_child(ground)
 
-	# Light
 	var light = DirectionalLight3D.new()
 	light.rotation.x = -PI / 4
 	light.rotation.y = -PI / 4
 	add_child(light)
 
-	# Camera
 	var camera = Camera3D.new()
 	camera.position = Vector3(0, 8, 15)
 	camera.look_at(Vector3(0, 0, 0), Vector3.UP)
@@ -50,14 +57,12 @@ func _spawn_all_pets():
 		pet.pet_id = pet_id
 		pet.pet_name = pet_info["name"]
 		pet.pet_type = pet_info["type"]
-		pet.health = pet_info["health"]
-		pet.happiness = pet_info["happiness"]
 
-		# Random position on island
 		pet.position = Vector3(randf_range(-10, 10), 0.5, randf_range(-10, 10))
 
 		add_child(pet)
 		pets_in_scene.append(pet)
+		pet_ids.append(pet_id)
 
 func _create_ui():
 	var ui = Control.new()
@@ -73,39 +78,158 @@ func _create_ui():
 	title.add_theme_font_size_override("font_size", 24)
 	ui.add_child(title)
 
+	# Coins display (top right)
+	_coins_label = Label.new()
+	_coins_label.text = "Coins: %d" % game_manager.coins
+	_coins_label.position = Vector2(10, 40)
+	_coins_label.add_theme_font_size_override("font_size", 18)
+	_coins_label.add_theme_color_override("font_color", Color.YELLOW)
+	ui.add_child(_coins_label)
+
 	# Instructions
 	var instructions = Label.new()
-	instructions.text = "Press ESC or B to go back to Hub"
-	instructions.position = Vector2(10, 60)
+	instructions.text = "UP/DOWN: select pet | F: feed (-5 coins) | P: play (+3 coins) | R: rest | ESC: back"
+	instructions.position = Vector2(10, 65)
+	instructions.add_theme_font_size_override("font_size", 12)
 	ui.add_child(instructions)
 
 	# Pet list
-	var pets_label = Label.new()
-	pets_label.text = "\nPets on this island:"
-	pets_label.position = Vector2(10, 110)
-	ui.add_child(pets_label)
+	_pet_list_label = Label.new()
+	_pet_list_label.position = Vector2(10, 95)
+	ui.add_child(_pet_list_label)
 
-	var y_offset = 140
-	var all_pets = game_manager.get_all_pets()
-	for pet_id in all_pets.keys():
-		var pet_info = all_pets[pet_id]
-		var pet_text = Label.new()
-		pet_text.text = "• %s (%s) - Health: %d/100, Happiness: %d/100" % [
-			pet_info["name"],
-			pet_info["type"],
-			pet_info["health"],
-			pet_info["happiness"]
-		]
-		pet_text.position = Vector2(20, y_offset)
-		ui.add_child(pet_text)
-		y_offset += 25
+	# Stats for selected pet
+	_stats_label = Label.new()
+	_stats_label.position = Vector2(10, 220)
+	_stats_label.add_theme_font_size_override("font_size", 14)
+	ui.add_child(_stats_label)
+
+	# Feedback message
+	_feedback_label = Label.new()
+	_feedback_label.position = Vector2(10, 340)
+	_feedback_label.add_theme_font_size_override("font_size", 16)
+	_feedback_label.add_theme_color_override("font_color", Color.GOLD)
+	ui.add_child(_feedback_label)
+
+func _highlight_selected():
+	if pet_ids.size() == 0:
+		return
+	var lines = ""
+	for i in range(pet_ids.size()):
+		var pid = pet_ids[i]
+		var info = game_manager.get_pet_info(pid)
+		var mood = game_manager.get_mood_emoji(pid)
+		var prefix = "> " if i == selected_pet_index else "  "
+		lines += "%s%s (%s) %s\n" % [prefix, info["name"], info["type"], mood]
+	_pet_list_label.text = lines
+
+func _update_stats_display():
+	if pet_ids.size() == 0:
+		_stats_label.text = "No pets on island."
+		return
+	var pid = pet_ids[selected_pet_index]
+	var info = game_manager.get_pet_info(pid)
+	var mood = game_manager.get_pet_mood(pid)
+	_stats_label.text = "--- %s (%s) --- Mood: %s\nHealth:    %d/100\nHappiness: %d/100\nHunger:    %d/100\nEnergy:    %d/100" % [
+		info["name"], info["type"], mood,
+		info["health"], info["happiness"], info["hunger"], info["energy"]
+	]
+
+func _show_feedback(msg: String):
+	_feedback_label.text = msg
+	_feedback_timer = 2.5
+
+func _process(delta: float):
+	if _feedback_timer > 0:
+		_feedback_timer -= delta
+		if _feedback_timer <= 0:
+			_feedback_label.text = ""
+
+func _on_stat_changed(_pet_id: int, _stat_name: String, _new_value: int):
+	_highlight_selected()
+	_update_stats_display()
+
+func _on_coins_changed(new_amount: int):
+	_coins_label.text = "Coins: %d" % new_amount
+
+func _get_selected_pet_name() -> String:
+	if pet_ids.size() == 0:
+		return ""
+	var pid = pet_ids[selected_pet_index]
+	var info = game_manager.get_pet_info(pid)
+	return info["name"]
+
+func _get_selected_pet() -> Pet:
+	if selected_pet_index < pets_in_scene.size():
+		return pets_in_scene[selected_pet_index]
+	return null
+
+func _action_feed():
+	if pet_ids.size() == 0:
+		return
+	if game_manager.coins < 5:
+		_show_feedback("Not enough coins! (need 5)")
+		return
+	var pid = pet_ids[selected_pet_index]
+	game_manager.modify_coins(-5)
+	game_manager.modify_stat(pid, "hunger", 20)
+	var pet_node = _get_selected_pet()
+	if pet_node:
+		pet_node.do_happy_reaction()
+	_show_feedback("%s loved the treats!" % _get_selected_pet_name())
+
+func _action_play():
+	if pet_ids.size() == 0:
+		return
+	var pid = pet_ids[selected_pet_index]
+	var info = game_manager.get_pet_info(pid)
+	if info["energy"] < 10:
+		_show_feedback("%s is too tired to play!" % info["name"])
+		return
+	game_manager.modify_stat(pid, "happiness", 15)
+	game_manager.modify_stat(pid, "energy", -10)
+	game_manager.modify_coins(3)
+	var pet_node = _get_selected_pet()
+	if pet_node:
+		pet_node.do_happy_reaction()
+	_show_feedback("%s had a great time playing! (+3 coins)" % _get_selected_pet_name())
+
+func _action_rest():
+	if pet_ids.size() == 0:
+		return
+	var pid = pet_ids[selected_pet_index]
+	game_manager.modify_stat(pid, "energy", 20)
+	_show_feedback("%s is resting... zzz" % _get_selected_pet_name())
 
 func _go_back():
 	get_tree().change_scene_to_file("res://scenes/Main.tscn")
 
 func _input(event):
 	if event is InputEventKey and event.pressed:
-		# Go back with ESC or B
 		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
 			_go_back()
+			return
+
+		if event.keycode == KEY_UP:
+			selected_pet_index = max(0, selected_pet_index - 1)
+			_highlight_selected()
+			_update_stats_display()
+			return
+
+		if event.keycode == KEY_DOWN:
+			selected_pet_index = min(pet_ids.size() - 1, selected_pet_index + 1)
+			_highlight_selected()
+			_update_stats_display()
+			return
+
+		if event.keycode == KEY_F:
+			_action_feed()
+			return
+
+		if event.keycode == KEY_P:
+			_action_play()
+			return
+
+		if event.keycode == KEY_R:
+			_action_rest()
 			return

--- a/scripts/Pet.gd
+++ b/scripts/Pet.gd
@@ -1,43 +1,171 @@
 extends Node3D
 
-# Pet visual representation in 3D
+# Pet visual representation in 3D — reads all stats from GameManager
 class_name Pet
 
 var pet_id: int
 var pet_name: String
 var pet_type: String  # "unicorn", "pegasus", "dragon"
-var health: int = 100
-var happiness: int = 100
+
+var _game_manager
+var _base_y: float = 0.0
+var _bob_time: float = 0.0
+var _label3d: Label3D
+var _body_mesh: MeshInstance3D
 
 func _ready():
-	# Create a simple 3D pet model
-	var mesh_instance = MeshInstance3D.new()
+	_game_manager = get_tree().root.get_node("GameManager")
+	_base_y = position.y
+
+	_build_body()
+	_build_legs()
+	_build_horn()
+	_build_type_features()
+	_build_label()
+
+	# Randomize bob phase so pets don't all bob in sync
+	_bob_time = randf() * TAU
+
+func _build_body():
+	_body_mesh = MeshInstance3D.new()
 	var sphere_mesh = SphereMesh.new()
 	sphere_mesh.radius = 0.5
 	sphere_mesh.height = 1.0
-	mesh_instance.mesh = sphere_mesh
+	_body_mesh.mesh = sphere_mesh
 
-	# Add a material
 	var material = StandardMaterial3D.new()
 	material.albedo_color = _get_pet_color()
-	mesh_instance.material_override = material
+	_body_mesh.material_override = material
 
-	add_child(mesh_instance)
+	add_child(_body_mesh)
 
-	# Add a simple horn (cone)
+func _build_legs():
+	var leg_positions = [
+		Vector3(-0.25, -0.5, -0.15),
+		Vector3(0.25, -0.5, -0.15),
+		Vector3(-0.25, -0.5, 0.15),
+		Vector3(0.25, -0.5, 0.15),
+	]
+	for pos in leg_positions:
+		var leg = MeshInstance3D.new()
+		var cyl = CylinderMesh.new()
+		cyl.top_radius = 0.06
+		cyl.bottom_radius = 0.06
+		cyl.height = 0.35
+		leg.mesh = cyl
+		leg.position = pos
+
+		var mat = StandardMaterial3D.new()
+		mat.albedo_color = _get_pet_color().darkened(0.1)
+		leg.material_override = mat
+
+		add_child(leg)
+
+func _build_horn():
+	# All pet types get a horn on the head (repositioned to head height)
+	if pet_type == "dragon":
+		return  # dragons don't have horns
 	var horn = MeshInstance3D.new()
 	var cone_mesh = CylinderMesh.new()
 	cone_mesh.top_radius = 0.0
 	cone_mesh.bottom_radius = 0.1
 	cone_mesh.height = 0.5
 	horn.mesh = cone_mesh
-	horn.position.y = 0.7
+	horn.position.y = 0.75
 
 	var horn_material = StandardMaterial3D.new()
 	horn_material.albedo_color = Color.YELLOW
 	horn.material_override = horn_material
 
 	add_child(horn)
+
+func _build_type_features():
+	match pet_type:
+		"pegasus":
+			# Wing boxes on each side
+			for side in [-1.0, 1.0]:
+				var wing = MeshInstance3D.new()
+				var box = BoxMesh.new()
+				box.size = Vector3(0.6, 0.05, 0.3)
+				wing.mesh = box
+				wing.position = Vector3(side * 0.65, 0.15, 0.0)
+				wing.rotation.z = side * -0.3
+
+				var mat = StandardMaterial3D.new()
+				mat.albedo_color = Color(0.85, 0.85, 0.95)
+				wing.material_override = mat
+
+				wing.name = "Wing_" + ("L" if side < 0 else "R")
+				add_child(wing)
+		"dragon":
+			# Tail cylinder behind
+			var tail = MeshInstance3D.new()
+			var cyl = CylinderMesh.new()
+			cyl.top_radius = 0.04
+			cyl.bottom_radius = 0.12
+			cyl.height = 0.6
+			tail.mesh = cyl
+			tail.position = Vector3(0, 0.0, 0.5)
+			tail.rotation.x = PI / 3
+
+			var mat = StandardMaterial3D.new()
+			mat.albedo_color = _get_pet_color().darkened(0.2)
+			tail.material_override = mat
+
+			add_child(tail)
+
+func _build_label():
+	_label3d = Label3D.new()
+	_label3d.position.y = 1.1
+	_label3d.font_size = 48
+	_label3d.billboard = BaseMaterial3D.BILLBOARD_ENABLED
+	_label3d.no_depth_test = true
+	_update_label()
+	add_child(_label3d)
+
+func _update_label():
+	if _label3d == null or _game_manager == null:
+		return
+	var emoji = _game_manager.get_mood_emoji(pet_id)
+	_label3d.text = pet_name + " " + emoji
+
+func _process(delta: float):
+	# Bobbing animation
+	_bob_time += delta
+	var mood = "content"
+	if _game_manager:
+		mood = _game_manager.get_pet_mood(pet_id)
+
+	var speed: float
+	var amplitude: float
+	match mood:
+		"happy":
+			speed = 3.0
+			amplitude = 0.15
+		"content":
+			speed = 2.0
+			amplitude = 0.1
+		"sad":
+			speed = 1.0
+			amplitude = 0.05
+		"hungry":
+			speed = 1.5
+			amplitude = 0.07
+		"resting":
+			speed = 0.5
+			amplitude = 0.03
+		_:
+			speed = 2.0
+			amplitude = 0.1
+
+	position.y = _base_y + sin(_bob_time * speed) * amplitude
+
+	_update_label()
+
+func do_happy_reaction():
+	var tween = create_tween()
+	tween.tween_property(self, "scale", Vector3(1.2, 1.2, 1.2), 0.15)
+	tween.tween_property(self, "scale", Vector3(1.0, 1.0, 1.0), 0.15)
 
 func _get_pet_color() -> Color:
 	match pet_type:
@@ -49,12 +177,3 @@ func _get_pet_color() -> Color:
 			return Color.RED
 		_:
 			return Color.WHITE
-
-func take_damage(amount: int):
-	health = max(0, health - amount)
-
-func heal(amount: int):
-	health = min(100, health + amount)
-
-func increase_happiness(amount: int):
-	happiness = min(100, happiness + amount)

--- a/scripts/VetClinic.gd
+++ b/scripts/VetClinic.gd
@@ -1,21 +1,19 @@
 extends Node3D
 
-# Vet Clinic scene - Keyboard only controls
+# Vet Clinic scene — healing costs coins, keyboard controls
 var game_manager
 var selected_pet_id = null
 var pet_list = []  # List of pet IDs
 var selected_pet_index = 0
 
+var _coins_label: Label
+
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 
-	# Create clinic environment
 	_create_clinic_environment()
-
-	# Create UI
 	_create_ui()
 
-	# Build pet list
 	var all_pets = game_manager.get_all_pets()
 	for pet_id in all_pets.keys():
 		pet_list.append(pet_id)
@@ -23,26 +21,25 @@ func _ready():
 	if pet_list.size() > 0:
 		_select_pet(pet_list[0])
 
+	game_manager.coins_changed.connect(_on_coins_changed)
+
 func _create_clinic_environment():
-	# Floor (white clinic floor)
-	var floor = MeshInstance3D.new()
+	var floor_node = MeshInstance3D.new()
 	var plane_mesh = PlaneMesh.new()
 	plane_mesh.size = Vector2(20, 20)
-	floor.mesh = plane_mesh
-	floor.position.y = -1
+	floor_node.mesh = plane_mesh
+	floor_node.position.y = -1
 
 	var floor_material = StandardMaterial3D.new()
 	floor_material.albedo_color = Color.WHITE
-	floor.material_override = floor_material
-	add_child(floor)
+	floor_node.material_override = floor_material
+	add_child(floor_node)
 
-	# Light (bright clinic light)
 	var light = DirectionalLight3D.new()
 	light.rotation.x = -PI / 3
 	light.rotation.y = 0
 	add_child(light)
 
-	# Camera
 	var camera = Camera3D.new()
 	camera.position = Vector3(0, 5, 10)
 	camera.look_at(Vector3(0, 0, 0), Vector3.UP)
@@ -62,20 +59,28 @@ func _create_ui():
 	title.add_theme_font_size_override("font_size", 24)
 	ui.add_child(title)
 
+	# Coins display
+	_coins_label = Label.new()
+	_coins_label.text = "Coins: %d (Heal costs 10)" % game_manager.coins
+	_coins_label.position = Vector2(10, 40)
+	_coins_label.add_theme_font_size_override("font_size", 16)
+	_coins_label.add_theme_color_override("font_color", Color.YELLOW)
+	ui.add_child(_coins_label)
+
 	# Instructions
 	var instructions = Label.new()
-	instructions.text = "UP/DOWN to select pet, H to heal, ESC to go back"
-	instructions.position = Vector2(10, 60)
+	instructions.text = "UP/DOWN to select pet, H to heal (10 coins), ESC to go back"
+	instructions.position = Vector2(10, 65)
 	ui.add_child(instructions)
 
 	# Pet selection area
 	var pet_label = Label.new()
-	pet_label.text = "\nSelect a pet to heal:"
-	pet_label.position = Vector2(10, 110)
+	pet_label.text = "Select a pet to heal:"
+	pet_label.position = Vector2(10, 100)
 	ui.add_child(pet_label)
 
 	var all_pets = game_manager.get_all_pets()
-	var y_offset = 140
+	var y_offset = 125
 
 	for pet_id in all_pets.keys():
 		var pet_info = all_pets[pet_id]
@@ -91,34 +96,46 @@ func _create_ui():
 	# Status label
 	var status_label = Label.new()
 	status_label.text = ""
-	status_label.position = Vector2(10, y_offset + 30)
+	status_label.position = Vector2(10, y_offset + 20)
 	status_label.name = "StatusLabel"
 	ui.add_child(status_label)
+
+func _on_coins_changed(new_amount: int):
+	_coins_label.text = "Coins: %d (Heal costs 10)" % new_amount
 
 func _select_pet(pet_id: int):
 	selected_pet_id = pet_id
 	var pet_info = game_manager.get_pet_info(pet_id)
+	var mood = game_manager.get_pet_mood(pet_id)
 
 	var status_label = get_node("UI/StatusLabel")
-	status_label.text = "\n> Selected: %s (%s)\n  Health: %d/100\n  Happiness: %d/100\n\nPress H to heal, or UP/DOWN to choose another pet" % [
+	status_label.text = "> Selected: %s (%s) — Mood: %s\n  Health: %d/100\n  Happiness: %d/100\n  Hunger: %d/100\n  Energy: %d/100\n\nPress H to heal, or UP/DOWN to choose another pet" % [
 		pet_info["name"],
 		pet_info["type"],
+		mood,
 		pet_info["health"],
-		pet_info["happiness"]
+		pet_info["happiness"],
+		pet_info["hunger"],
+		pet_info["energy"]
 	]
 
 	# Update visual highlighting
 	var all_pets = game_manager.get_all_pets()
 	for pid in all_pets.keys():
 		var pet_text = get_node("UI/Pet_%d" % pid)
+		var pinfo = all_pets[pid]
 		if pid == pet_id:
-			pet_text.text = "> %s (%s) - Health: %d/100" % [all_pets[pid]["name"], all_pets[pid]["type"], all_pets[pid]["health"]]
+			pet_text.text = "> %s (%s) - Health: %d/100" % [pinfo["name"], pinfo["type"], pinfo["health"]]
 		else:
-			pet_text.text = "  %s (%s) - Health: %d/100" % [all_pets[pid]["name"], all_pets[pid]["type"], all_pets[pid]["health"]]
+			pet_text.text = "  %s (%s) - Health: %d/100" % [pinfo["name"], pinfo["type"], pinfo["health"]]
 
 func _heal_pet():
 	if selected_pet_id == null:
-		print("No pet selected!")
+		return
+
+	if game_manager.coins < 10:
+		var status_label = get_node("UI/StatusLabel")
+		status_label.text = "Not enough coins! Healing costs 10 coins.\nYou have %d coins.\n\nVisit the Island and play with pets to earn coins!" % game_manager.coins
 		return
 
 	var success = game_manager.heal_pet(selected_pet_id, 30)
@@ -126,33 +143,27 @@ func _heal_pet():
 	if success:
 		var pet_info = game_manager.get_pet_info(selected_pet_id)
 		var status_label = get_node("UI/StatusLabel")
-		status_label.text = "\n✓ HEALED! %s's health increased to %d/100\n\nPress H to heal again, or UP/DOWN to select another pet" % [
+		status_label.text = "HEALED! %s's health increased to %d/100 (-10 coins)\n\nPress H to heal again, or UP/DOWN to select another pet" % [
 			pet_info["name"],
 			pet_info["health"]
 		]
 
-		# Update pet display
 		var pet_text = get_node("UI/Pet_%d" % selected_pet_id)
 		pet_text.text = "> %s (%s) - Health: %d/100" % [pet_info["name"], pet_info["type"], pet_info["health"]]
-
-		print("Healed pet: ", pet_info["name"])
 
 func _go_back():
 	get_tree().change_scene_to_file("res://scenes/Main.tscn")
 
 func _input(event):
 	if event is InputEventKey and event.pressed:
-		# Go back with ESC
 		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
 			_go_back()
 			return
 
-		# Heal with H
 		if event.keycode == KEY_H:
 			_heal_pet()
 			return
 
-		# Navigate pets with arrow keys
 		if event.keycode == KEY_UP:
 			selected_pet_index = max(0, selected_pet_index - 1)
 			if selected_pet_index < pet_list.size():


### PR DESCRIPTION
## Summary
- **GameManager refactor**: Sequential pet IDs, hunger/energy stats, coins system (start at 50), signals for stat/coin/mood changes, 60-second decay tick (hunger -2, happiness -1, floor at 10), mood system (happy/content/sad/hungry/resting), health decay from low stats, resting state at health 0
- **Pet animations**: Idle bobbing animation (sine wave) with speed/amplitude varying by mood, Label3D showing name + mood emoji (^_^, -_-, T_T, >_<, zzZ), happy reaction tween (scale 1.2x bounce), legs (4 cylinders), pegasus wing boxes, dragon tail cylinder
- **Island interactions**: Pet selection with UP/DOWN, Feed (F key, +20 hunger, -5 coins), Play (P key, +15 happiness, -10 energy, +3 coins), Rest (R key, +20 energy), full 4-stat display for selected pet, coin counter, feedback messages
- **Vet costs coins**: Healing costs 10 coins per use, coin balance display, "not enough coins" warning with guidance
- **Hub improvements**: VBoxContainer/HBoxContainer layout replacing pixel positioning, pet mood summaries with emoji and lowest-stat warnings (color-coded), coin display, gameplay tips

## Test plan
- [ ] Verify pets bob with different speeds based on mood (happy=fast, sad=slow)
- [ ] Verify Label3D shows pet name and mood emoji above each pet
- [ ] On Island: select pets with UP/DOWN, feed with F (coins decrease by 5, hunger +20), play with P (coins +3, happiness +15, energy -10), rest with R (energy +20)
- [ ] Verify "not enough coins" feedback when coins < 5 for feeding
- [ ] Verify stat decay occurs every 60 seconds (hunger -2, happiness -1)
- [ ] Verify low hunger (<20) accelerates happiness decay
- [ ] Verify low happiness (<20) causes health decay
- [ ] At Vet: healing costs 10 coins, shows balance, warns if insufficient
- [ ] Hub shows mood summaries with emoji and low-stat warnings
- [ ] Hub displays coin count

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)