### PR TITLE
feat: weather, new pets, mini-games, and QoL improvements (v1.2.0)

### DIFF
--- a/scenes/MathGame.tscn
+++ b/scenes/MathGame.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/MathGame.gd" id="1"]
+
+[node name="MathGame" type="Node2D"]
+script = ExtResource("1")

--- a/scenes/SpellingGame.tscn
+++ b/scenes/SpellingGame.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/SpellingGame.gd" id="1"]
+
+[node name="SpellingGame" type="Node2D"]
+script = ExtResource("1")

--- a/scenes/SudokuGame.tscn
+++ b/scenes/SudokuGame.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/SudokuGame.gd" id="1"]
+
+[node name="SudokuGame" type="Node2D"]
+script = ExtResource("1")

--- a/scripts/AchievementManager.gd
+++ b/scripts/AchievementManager.gd
@@ -12,6 +12,15 @@ const ACHIEVEMENTS = {
 	"mini_game_master": {"name": "Mini-Game Master", "desc": "Score 50+ in mini-game", "reward": 30},
 	"coin_collector": {"name": "Coin Collector", "desc": "Earn 500 total coins", "reward": 50},
 	"dedicated_caretaker": {"name": "Dedicated Caretaker", "desc": "Play for 1 hour total", "reward": 30},
+	"dog_lover": {"name": "Dog Lover", "desc": "Own 3 dog-o-corns", "reward": 30},
+	"cat_lover": {"name": "Cat Lover", "desc": "Own 3 cat-o-corns", "reward": 30},
+	"animal_ark": {"name": "Animal Ark", "desc": "Own one of every pet type", "reward": 100},
+	"koala_friend": {"name": "Koala Friend", "desc": "Have a pet with a koala rider", "reward": 20},
+	"math_whiz": {"name": "Math Whiz", "desc": "Get 20 correct in Math Challenge", "reward": 40},
+	"puzzle_solver": {"name": "Puzzle Solver", "desc": "Complete 5 Sudoku puzzles", "reward": 30},
+	"no_hints": {"name": "No Hints Needed", "desc": "Complete a Sudoku without hints", "reward": 20},
+	"spelling_bee": {"name": "Spelling Bee", "desc": "Get 15 correct in Spelling Game", "reward": 35},
+	"word_master": {"name": "Word Master", "desc": "Get 10 correct on Hard spelling", "reward": 50},
 }
 
 var _unlocked: Array = []
@@ -66,6 +75,35 @@ func check_all():
 	if dragon_count >= 3:
 		_try_unlock("dragon_keeper")
 
+	# Dog Lover
+	var dog_count = 0
+	for pid in all_pets.keys():
+		if all_pets[pid]["type"] == "dogocorn":
+			dog_count += 1
+	if dog_count >= 3:
+		_try_unlock("dog_lover")
+
+	# Cat Lover
+	var cat_count = 0
+	for pid in all_pets.keys():
+		if all_pets[pid]["type"] == "catocorn":
+			cat_count += 1
+	if cat_count >= 3:
+		_try_unlock("cat_lover")
+
+	# Animal Ark (one of every pet type)
+	var types_owned = {}
+	for pid in all_pets.keys():
+		types_owned[all_pets[pid]["type"]] = true
+	if types_owned.size() >= 6:
+		_try_unlock("animal_ark")
+
+	# Koala Friend
+	for pid in all_pets.keys():
+		if all_pets[pid].get("has_koala", false):
+			_try_unlock("koala_friend")
+			break
+
 	# Happy Family
 	if all_pets.size() > 0:
 		var all_happy = true
@@ -87,6 +125,22 @@ func check_all():
 func check_mini_game_score(score: int):
 	if score >= 50:
 		_try_unlock("mini_game_master")
+
+func check_math_score(correct_count: int):
+	if correct_count >= 20:
+		_try_unlock("math_whiz")
+
+func check_sudoku_complete(puzzles_completed: int, hints_used: int):
+	if puzzles_completed >= 5:
+		_try_unlock("puzzle_solver")
+	if hints_used == 0:
+		_try_unlock("no_hints")
+
+func check_spelling_score(correct_count: int, was_hard: bool):
+	if correct_count >= 15:
+		_try_unlock("spelling_bee")
+	if was_hard and correct_count >= 10:
+		_try_unlock("word_master")
 
 func _try_unlock(achievement_id: String):
 	if achievement_id in _unlocked:

--- a/scripts/AudioManager.gd
+++ b/scripts/AudioManager.gd
@@ -4,11 +4,12 @@ extends Node
 
 var _sfx_player: AudioStreamPlayer
 var _muted: bool = false
-var _volume_db: float = 0.0
+var _volume_db: float = -8.0  # softer default volume
 
 func _ready():
 	_sfx_player = AudioStreamPlayer.new()
 	_sfx_player.bus = "Master"
+	_sfx_player.volume_db = _volume_db
 	add_child(_sfx_player)
 
 func _input(event):
@@ -45,6 +46,14 @@ func _generate_sfx(sfx_name: String) -> AudioStreamWAV:
 			return _make_tone_sequence([330, 262], 0.1)
 		"win":
 			return _make_tone_sequence([523, 659, 784, 1047], 0.12)
+		"correct":
+			return _make_tone_sequence([523, 659, 784], 0.08)
+		"wrong":
+			return _make_tone_sequence([330, 262], 0.08)
+		"bark":
+			return _make_tone_sequence([200, 350, 200], 0.06)
+		"meow":
+			return _make_tone_sequence([600, 500, 400], 0.1)
 		_:
 			return null
 
@@ -66,7 +75,7 @@ func _make_tone_sequence(frequencies: Array, note_duration: float) -> AudioStrea
 			var t: float = float(i) / sample_rate
 			var envelope: float = 1.0 - (float(i) / samples_per_note)
 			envelope = envelope * envelope  # quadratic decay
-			var sample_val: float = sin(t * freq * TAU) * envelope * 0.4
+			var sample_val: float = sin(t * freq * TAU) * envelope * 0.25
 			var byte_val: int = clampi(int((sample_val + 0.5) * 255), 0, 255)
 			data[n * samples_per_note + i] = byte_val
 

--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -32,9 +32,11 @@ const LEVEL_THRESHOLDS: Array = [0, 50, 120, 250, 500, 900, 1400, 2000, 2800, 38
 
 # Whimsical name parts for hatched pets
 const NAME_PREFIXES: Array = ["Star", "Moon", "Sun", "Cloud", "Crystal", "Shadow",
-	"Glitter", "Shimmer", "Frost", "Ember", "Misty", "Velvet", "Dream", "Dusk", "Dawn"]
+	"Glitter", "Shimmer", "Frost", "Ember", "Misty", "Velvet", "Dream", "Dusk", "Dawn",
+	"Biscuit", "Honey", "Whisker", "Paws", "Clover"]
 const NAME_SUFFIXES: Array = ["whisper", "beam", "hooves", "mane", "spark", "shine",
-	"dancer", "song", "flight", "heart", "dust", "glow", "petal", "breeze", "storm"]
+	"dancer", "song", "flight", "heart", "dust", "glow", "petal", "breeze", "storm",
+	"paws", "nose", "fur", "tail", "ears"]
 
 # Color variants per pet type
 const COLOR_VARIANTS = {
@@ -42,6 +44,8 @@ const COLOR_VARIANTS = {
 	"pegasus": [Color.LIGHT_GRAY, Color(0.75, 0.75, 0.75), Color(0.53, 0.81, 0.92), Color(0.73, 0.56, 0.87)],
 	"dragon": [Color.RED, Color(0.0, 0.75, 0.0), Color(0.4, 0.0, 0.6), Color(1.0, 0.5, 0.0)],
 	"alicorn": [Color(0.6, 0.2, 0.8), Color(0.1, 0.1, 0.7), Color.WHITE],
+	"dogocorn": [Color(0.72, 0.53, 0.34), Color(0.95, 0.87, 0.73), Color(0.3, 0.3, 0.3), Color(1.0, 0.85, 0.6)],
+	"catocorn": [Color(0.95, 0.6, 0.2), Color(0.2, 0.2, 0.2), Color(0.85, 0.85, 0.85), Color(0.75, 0.55, 0.35)],
 }
 
 func _ready():
@@ -91,6 +95,7 @@ func _load_saved_data():
 			"xp": int(pet_data.get("xp", 0)),
 			"level": int(pet_data.get("level", 1)),
 			"color_variant": int(pet_data.get("color_variant", 0)),
+			"has_koala": bool(pet_data.get("has_koala", false)),
 		}
 
 	# Restore egg inventory
@@ -218,12 +223,16 @@ func _generate_whimsical_name() -> String:
 
 func _roll_egg_type() -> String:
 	var roll = randf()
-	if roll < 0.50:
+	if roll < 0.30:
 		return "unicorn"
-	elif roll < 0.75:
+	elif roll < 0.50:
 		return "pegasus"
-	elif roll < 0.95:
+	elif roll < 0.65:
 		return "dragon"
+	elif roll < 0.77:
+		return "dogocorn"
+	elif roll < 0.89:
+		return "catocorn"
 	else:
 		return "alicorn"
 
@@ -251,6 +260,7 @@ func add_pet(pet_name: String, pet_type: String) -> int:
 		"xp": 0,
 		"level": 1,
 		"color_variant": 0,
+		"has_koala": randf() < 0.2,
 	}
 	return pet_id
 

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -3,8 +3,8 @@ extends Node3D
 # Main game scene (Hub) — mood summaries, coins, eggs, achievements
 var game_manager
 var audio_manager
-var selected_menu_item = 0  # 0 = Island, 1 = Vet, 2 = Mini-Game, 3 = Memory Game, 4 = Achievements
-var menu_count = 5
+var selected_menu_item = 0
+var menu_count = 8
 
 var _pets_container: VBoxContainer
 var _coins_label: Label
@@ -146,7 +146,7 @@ func _create_ui():
 
 	# Gameplay tips
 	var tips = Label.new()
-	tips.text = "Tips: Visit the Island to feed, play, and rest with your pets.\nCollect eggs on the Island — they hatch into new pets!\nEarn coins by playing! Try Mini-Game or Memory Match for extra coins!"
+	tips.text = "Tips: Visit the Island to feed, play, and rest with your pets.\nCollect eggs on the Island — they hatch into new pets!\nEarn coins by playing! Try the mini-games for extra coins!\nCtrl+S to save anytime."
 	tips.add_theme_font_size_override("font_size", 12)
 	tips.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
 	vbox.add_child(tips)
@@ -179,8 +179,9 @@ func _refresh_pet_list():
 		if lowest_val < 30:
 			warning = "  [!%s: %d]" % [lowest_name, lowest_val]
 
+		var koala_str = " [K]" if info.get("has_koala", false) else ""
 		var row = Label.new()
-		row.text = "%s %s Lv%d (%s) — %s%s" % [emoji, info["name"], level, info["type"], mood, warning]
+		row.text = "%s %s Lv%d (%s)%s — %s%s" % [emoji, info["name"], level, info["type"], koala_str, mood, warning]
 
 		if lowest_val < 20:
 			row.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
@@ -257,6 +258,24 @@ func _go_to_memory_game():
 		save_manager.on_scene_transition()
 	get_tree().change_scene_to_file("res://scenes/MemoryGame.tscn")
 
+func _go_to_math_game():
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/MathGame.tscn")
+
+func _go_to_sudoku():
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/SudokuGame.tscn")
+
+func _go_to_spelling():
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/SpellingGame.tscn")
+
 func _go_to_achievements():
 	var save_manager = get_tree().root.get_node_or_null("SaveManager")
 	if save_manager:
@@ -269,8 +288,11 @@ func _update_menu_display():
 	var options = [
 		"Visit Island (Q)",
 		"Visit Vet (V)",
-		"Play Mini-Game (T)",
+		"Play Treat Catch (T)",
 		"Memory Match (G)",
+		"Math Challenge (N)",
+		"Sudoku Puzzle (U)",
+		"Spelling Bee (L)",
 		"Achievements (A)"
 	]
 	var text = ""
@@ -293,6 +315,13 @@ func _input(event):
 		if _welcome_label.visible:
 			_welcome_label.visible = false
 
+		# Manual save
+		if event.keycode == KEY_S and event.ctrl_pressed:
+			var save_manager = get_tree().root.get_node_or_null("SaveManager")
+			if save_manager:
+				save_manager.save_game()
+			return
+
 		if event.keycode == KEY_Q:
 			_go_to_island()
 			return
@@ -304,6 +333,15 @@ func _input(event):
 			return
 		if event.keycode == KEY_G:
 			_go_to_memory_game()
+			return
+		if event.keycode == KEY_N:
+			_go_to_math_game()
+			return
+		if event.keycode == KEY_U:
+			_go_to_sudoku()
+			return
+		if event.keycode == KEY_L:
+			_go_to_spelling()
 			return
 		if event.keycode == KEY_A:
 			_go_to_achievements()
@@ -335,5 +373,11 @@ func _input(event):
 				3:
 					_go_to_memory_game()
 				4:
+					_go_to_math_game()
+				5:
+					_go_to_sudoku()
+				6:
+					_go_to_spelling()
+				7:
 					_go_to_achievements()
 			return

--- a/scripts/MathGame.gd
+++ b/scripts/MathGame.gd
@@ -1,0 +1,329 @@
+extends Node2D
+
+# Math Game — Times Tables practice
+# UP/DOWN to select answer, SPACE to confirm, difficulty levels, coin rewards
+
+var game_manager
+var audio_manager
+
+# Game state
+const GAME_DURATION: float = 60.0
+var _time_remaining: float = GAME_DURATION
+var _game_active: bool = false
+var _score: int = 0
+var _coins_earned: int = 0
+var _correct_count: int = 0
+var _wrong_count: int = 0
+var _active_pet_id: int = -1
+var _streak: int = 0
+
+# Difficulty
+var difficulty: int = 1  # 0=easy(1-5), 1=medium(1-10), 2=hard(1-12)
+var selecting_difficulty: bool = true
+
+# Current problem
+var _factor_a: int = 0
+var _factor_b: int = 0
+var _correct_answer: int = 0
+var _choices: Array = []
+var _selected_choice: int = 0
+
+# UI elements
+var _time_label: Label
+var _score_label: Label
+var _problem_label: Label
+var _choices_labels: Array = []
+var _feedback_label: Label
+var _result_label: Label
+var _difficulty_label: Label
+var _info_label: Label
+var _streak_label: Label
+
+var _screen_width: float = 1152.0
+var _screen_height: float = 648.0
+
+func _ready():
+	game_manager = get_tree().root.get_node("GameManager")
+	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+
+	var all_pets = game_manager.get_all_pets()
+	if all_pets.size() > 0:
+		_active_pet_id = all_pets.keys()[0]
+
+	var viewport_size = get_viewport().get_visible_rect().size
+	if viewport_size.x > 0:
+		_screen_width = viewport_size.x
+		_screen_height = viewport_size.y
+
+	_build_ui()
+	_show_difficulty_select()
+
+func _build_ui():
+	# Background
+	var bg = ColorRect.new()
+	bg.color = Color(0.1, 0.15, 0.3)
+	bg.size = Vector2(_screen_width, _screen_height)
+	add_child(bg)
+
+	# Title
+	var title = Label.new()
+	title.text = "MATH CHALLENGE"
+	title.position = Vector2(_screen_width / 2.0 - 100, 10)
+	title.add_theme_font_size_override("font_size", 28)
+	title.add_theme_color_override("font_color", Color(0.3, 0.9, 0.3))
+	add_child(title)
+
+	# Time display
+	_time_label = Label.new()
+	_time_label.position = Vector2(15, 15)
+	_time_label.add_theme_font_size_override("font_size", 20)
+	add_child(_time_label)
+
+	# Score display
+	_score_label = Label.new()
+	_score_label.position = Vector2(_screen_width - 250, 15)
+	_score_label.add_theme_font_size_override("font_size", 20)
+	_score_label.add_theme_color_override("font_color", Color.YELLOW)
+	add_child(_score_label)
+
+	# Streak display
+	_streak_label = Label.new()
+	_streak_label.position = Vector2(_screen_width - 250, 42)
+	_streak_label.add_theme_font_size_override("font_size", 16)
+	_streak_label.add_theme_color_override("font_color", Color(1.0, 0.6, 0.2))
+	add_child(_streak_label)
+
+	# Problem display (large, centered)
+	_problem_label = Label.new()
+	_problem_label.position = Vector2(_screen_width / 2.0 - 120, 120)
+	_problem_label.add_theme_font_size_override("font_size", 48)
+	_problem_label.add_theme_color_override("font_color", Color.WHITE)
+	_problem_label.visible = false
+	add_child(_problem_label)
+
+	# Answer choices (4 options)
+	for i in range(4):
+		var choice = Label.new()
+		choice.position = Vector2(_screen_width / 2.0 - 80, 220 + i * 55)
+		choice.add_theme_font_size_override("font_size", 28)
+		choice.visible = false
+		add_child(choice)
+		_choices_labels.append(choice)
+
+	# Feedback
+	_feedback_label = Label.new()
+	_feedback_label.position = Vector2(_screen_width / 2.0 - 100, 460)
+	_feedback_label.add_theme_font_size_override("font_size", 20)
+	add_child(_feedback_label)
+
+	# Info/instructions
+	_info_label = Label.new()
+	_info_label.position = Vector2(15, _screen_height - 30)
+	_info_label.add_theme_font_size_override("font_size", 12)
+	_info_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	add_child(_info_label)
+
+	# Difficulty selector
+	_difficulty_label = Label.new()
+	_difficulty_label.position = Vector2(300, 200)
+	_difficulty_label.add_theme_font_size_override("font_size", 18)
+	add_child(_difficulty_label)
+
+	# Result (hidden)
+	_result_label = Label.new()
+	_result_label.position = Vector2(_screen_width / 2.0 - 150, _screen_height / 2.0 - 80)
+	_result_label.add_theme_font_size_override("font_size", 22)
+	_result_label.visible = false
+	add_child(_result_label)
+
+func _show_difficulty_select():
+	selecting_difficulty = true
+	_update_difficulty_display()
+	_info_label.text = "UP/DOWN: choose difficulty | SPACE: start | ESC: back to hub"
+
+func _update_difficulty_display():
+	var lines = ""
+	var options = ["Easy (1-5 tables)", "Medium (1-10 tables)", "Hard (1-12 tables)"]
+	for i in range(options.size()):
+		var prefix = "> " if i == difficulty else "  "
+		lines += prefix + options[i] + "\n"
+	_difficulty_label.text = "Choose Difficulty:\n\n" + lines
+
+func _start_game():
+	selecting_difficulty = false
+	_difficulty_label.text = ""
+	_game_active = true
+	_time_remaining = GAME_DURATION
+	_score = 0
+	_coins_earned = 0
+	_correct_count = 0
+	_wrong_count = 0
+	_streak = 0
+
+	_problem_label.visible = true
+	for label in _choices_labels:
+		label.visible = true
+	_result_label.visible = false
+
+	_info_label.text = "UP/DOWN: select answer | SPACE: confirm | ESC: back"
+	_generate_problem()
+	_update_ui()
+
+func _generate_problem():
+	var max_factor = 5
+	match difficulty:
+		0: max_factor = 5
+		1: max_factor = 10
+		2: max_factor = 12
+
+	_factor_a = randi_range(1, max_factor)
+	_factor_b = randi_range(1, max_factor)
+	_correct_answer = _factor_a * _factor_b
+
+	# Generate 3 wrong answers (distinct, positive, plausible)
+	var wrong_answers: Array = []
+	var attempts = 0
+	while wrong_answers.size() < 3 and attempts < 50:
+		attempts += 1
+		var wrong: int
+		var strategy = randi() % 4
+		match strategy:
+			0: wrong = _correct_answer + randi_range(-5, 5)
+			1: wrong = _factor_a + _factor_b  # common mistake: addition
+			2: wrong = randi_range(1, max_factor) * randi_range(1, max_factor)
+			3: wrong = _correct_answer + randi_range(1, 3) * (1 if randi() % 2 == 0 else -1)
+		if wrong > 0 and wrong != _correct_answer and wrong not in wrong_answers:
+			wrong_answers.append(wrong)
+
+	while wrong_answers.size() < 3:
+		wrong_answers.append(_correct_answer + wrong_answers.size() + 1)
+
+	_choices = [_correct_answer] + wrong_answers
+	_choices.shuffle()
+	_selected_choice = 0
+
+	_problem_label.text = "%d x %d = ?" % [_factor_a, _factor_b]
+	_draw_choices()
+
+func _draw_choices():
+	for i in range(4):
+		var prefix = "> " if i == _selected_choice else "  "
+		_choices_labels[i].text = prefix + str(_choices[i])
+		if i == _selected_choice:
+			_choices_labels[i].add_theme_color_override("font_color", Color.GOLD)
+		else:
+			_choices_labels[i].add_theme_color_override("font_color", Color.WHITE)
+
+func _submit_answer():
+	if _choices[_selected_choice] == _correct_answer:
+		_correct_count += 1
+		_streak += 1
+		var bonus = 2
+		if _streak >= 5:
+			bonus = 4  # streak bonus
+		elif _streak >= 3:
+			bonus = 3
+		_coins_earned += bonus
+		game_manager.modify_coins(bonus)
+		if audio_manager:
+			audio_manager.play_sfx("correct")
+		_feedback_label.text = "Correct! +%d coins" % bonus
+		_feedback_label.add_theme_color_override("font_color", Color(0.3, 1.0, 0.3))
+	else:
+		_wrong_count += 1
+		_streak = 0
+		if audio_manager:
+			audio_manager.play_sfx("wrong")
+		_feedback_label.text = "Wrong! %d x %d = %d" % [_factor_a, _factor_b, _correct_answer]
+		_feedback_label.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
+
+	# Next problem
+	_generate_problem()
+
+func _update_ui():
+	_time_label.text = "Time: %d" % ceili(_time_remaining)
+	_score_label.text = "Correct: %d | Coins: +%d" % [_correct_count, _coins_earned]
+	_streak_label.text = "Streak: %d" % _streak if _streak >= 2 else ""
+
+func _end_game():
+	_game_active = false
+
+	if _active_pet_id >= 0 and _correct_count > 0:
+		game_manager.modify_stat(_active_pet_id, "happiness", _correct_count * 2)
+		game_manager.add_xp(_active_pet_id, _correct_count * 5)
+
+	var achievement_mgr = get_tree().root.get_node_or_null("AchievementManager")
+	if achievement_mgr:
+		achievement_mgr.check_math_score(_correct_count)
+		achievement_mgr.check_all()
+
+	# Hide game elements
+	_problem_label.visible = false
+	for label in _choices_labels:
+		label.visible = false
+	_feedback_label.text = ""
+
+	var xp_bonus = _correct_count * 5
+	_result_label.text = "TIME'S UP!\n\nCorrect: %d\nWrong: %d\nCoins earned: %d\nXP bonus: +%d\n\nPress ESC to return to Hub" % [
+		_correct_count, _wrong_count, max(0, _coins_earned), xp_bonus
+	]
+	_result_label.visible = true
+
+func _process(delta: float):
+	if not _game_active:
+		return
+
+	_time_remaining -= delta
+	if _time_remaining <= 0:
+		_end_game()
+		return
+
+	_update_ui()
+
+func _go_back():
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/Main.tscn")
+
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
+			_go_back()
+			return
+
+		# Manual save
+		if event.keycode == KEY_S and event.ctrl_pressed:
+			var save_manager = get_tree().root.get_node_or_null("SaveManager")
+			if save_manager:
+				save_manager.save_game()
+			return
+
+		if selecting_difficulty:
+			if event.keycode == KEY_UP:
+				difficulty = max(0, difficulty - 1)
+				_update_difficulty_display()
+				if audio_manager:
+					audio_manager.play_sfx("menu_navigate")
+			elif event.keycode == KEY_DOWN:
+				difficulty = min(2, difficulty + 1)
+				_update_difficulty_display()
+				if audio_manager:
+					audio_manager.play_sfx("menu_navigate")
+			elif event.keycode == KEY_SPACE:
+				if audio_manager:
+					audio_manager.play_sfx("menu_select")
+				_start_game()
+			return
+
+		if not _game_active:
+			return
+
+		if event.keycode == KEY_UP:
+			_selected_choice = max(0, _selected_choice - 1)
+			_draw_choices()
+		elif event.keycode == KEY_DOWN:
+			_selected_choice = min(3, _selected_choice + 1)
+			_draw_choices()
+		elif event.keycode == KEY_SPACE:
+			_submit_answer()

--- a/scripts/SpellingGame.gd
+++ b/scripts/SpellingGame.gd
@@ -1,0 +1,387 @@
+extends Node2D
+
+# Spelling Game — multiple choice: which is the correct spelling?
+# UP/DOWN to highlight choice, SPACE to confirm
+
+var game_manager
+var audio_manager
+
+# Word lists by difficulty
+const WORDS_EASY: Array = [
+	{"word": "cat", "wrong": ["kat", "catt", "cht"]},
+	{"word": "dog", "wrong": ["dgo", "dogg", "dag"]},
+	{"word": "sun", "wrong": ["son", "sunn", "san"]},
+	{"word": "red", "wrong": ["rad", "redd", "erd"]},
+	{"word": "big", "wrong": ["bag", "bigg", "beg"]},
+	{"word": "hat", "wrong": ["hatt", "het", "hit"]},
+	{"word": "run", "wrong": ["rann", "runn", "rin"]},
+	{"word": "cup", "wrong": ["kup", "cupp", "cap"]},
+	{"word": "bed", "wrong": ["bedd", "beed", "bid"]},
+	{"word": "map", "wrong": ["mapp", "mep", "nap"]},
+	{"word": "fish", "wrong": ["fich", "fis", "fhis"]},
+	{"word": "book", "wrong": ["bouk", "buk", "bok"]},
+	{"word": "tree", "wrong": ["tre", "trea", "trey"]},
+	{"word": "star", "wrong": ["starr", "sdar", "sttar"]},
+	{"word": "moon", "wrong": ["mune", "monn", "moun"]},
+	{"word": "bird", "wrong": ["brid", "birrd", "burd"]},
+	{"word": "frog", "wrong": ["frogg", "forg", "froq"]},
+	{"word": "cake", "wrong": ["caek", "kake", "cak"]},
+]
+
+const WORDS_MEDIUM: Array = [
+	{"word": "happy", "wrong": ["hapy", "hppy", "happey"]},
+	{"word": "friend", "wrong": ["freind", "frend", "freend"]},
+	{"word": "school", "wrong": ["skool", "scool", "shool"]},
+	{"word": "because", "wrong": ["becuase", "becuz", "becouse"]},
+	{"word": "people", "wrong": ["peple", "poeple", "peeple"]},
+	{"word": "animal", "wrong": ["animle", "anmal", "anmial"]},
+	{"word": "family", "wrong": ["famly", "famliy", "famely"]},
+	{"word": "garden", "wrong": ["gardan", "graden", "gardin"]},
+	{"word": "dragon", "wrong": ["dragin", "dragan", "dragen"]},
+	{"word": "castle", "wrong": ["castel", "cassle", "cassel"]},
+	{"word": "magic", "wrong": ["majic", "magik", "maigc"]},
+	{"word": "princess", "wrong": ["prinsess", "princes", "prinses"]},
+	{"word": "rainbow", "wrong": ["rainbo", "ranbow", "rainebow"]},
+	{"word": "sparkle", "wrong": ["sparcle", "sparkl", "spakle"]},
+	{"word": "special", "wrong": ["speshal", "specal", "spechial"]},
+	{"word": "unicorn", "wrong": ["unikorn", "unicron", "unocorn"]},
+	{"word": "kitchen", "wrong": ["kichen", "kitchin", "kitchan"]},
+	{"word": "weather", "wrong": ["wether", "wheather", "weater"]},
+]
+
+const WORDS_HARD: Array = [
+	{"word": "adventure", "wrong": ["adventur", "advenchure", "advencher"]},
+	{"word": "treasure", "wrong": ["tresure", "treasur", "tresher"]},
+	{"word": "mysterious", "wrong": ["misterious", "mystirious", "mysterius"]},
+	{"word": "enormous", "wrong": ["enormus", "enourmous", "enormos"]},
+	{"word": "brilliant", "wrong": ["brillant", "briliant", "brillent"]},
+	{"word": "incredible", "wrong": ["incredable", "increadible", "incredibel"]},
+	{"word": "beautiful", "wrong": ["beutiful", "beautful", "butiful"]},
+	{"word": "imagination", "wrong": ["imagenation", "imaginashun", "imanigation"]},
+	{"word": "extraordinary", "wrong": ["extrordinary", "extraodinary", "extreordinary"]},
+	{"word": "disappear", "wrong": ["dissapear", "disapear", "disappeer"]},
+	{"word": "different", "wrong": ["diffrent", "differant", "diferent"]},
+	{"word": "necessary", "wrong": ["neccessary", "necesary", "neccesary"]},
+	{"word": "separate", "wrong": ["seperate", "separete", "seprate"]},
+	{"word": "Wednesday", "wrong": ["Wensday", "Wedensday", "Wendesday"]},
+	{"word": "strength", "wrong": ["strenth", "strenght", "stength"]},
+]
+
+# Game state
+const GAME_DURATION: float = 60.0
+var _time_remaining: float = GAME_DURATION
+var _game_active: bool = false
+var _correct_count: int = 0
+var _wrong_count: int = 0
+var _coins_earned: int = 0
+var _active_pet_id: int = -1
+
+# Difficulty
+var difficulty: int = 0
+var selecting_difficulty: bool = true
+
+# Current question
+var _current_word: String = ""
+var _choices: Array = []
+var _selected_choice: int = 0
+var _used_words: Array = []
+
+# UI
+var _time_label: Label
+var _score_label: Label
+var _prompt_label: Label
+var _choices_labels: Array = []
+var _feedback_label: Label
+var _result_label: Label
+var _difficulty_label: Label
+var _info_label: Label
+var _feedback_timer: float = 0.0
+var _waiting_next: bool = false
+
+var _screen_width: float = 1152.0
+var _screen_height: float = 648.0
+
+func _ready():
+	game_manager = get_tree().root.get_node("GameManager")
+	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+
+	var all_pets = game_manager.get_all_pets()
+	if all_pets.size() > 0:
+		_active_pet_id = all_pets.keys()[0]
+
+	var viewport_size = get_viewport().get_visible_rect().size
+	if viewport_size.x > 0:
+		_screen_width = viewport_size.x
+		_screen_height = viewport_size.y
+
+	_build_ui()
+	_show_difficulty_select()
+
+func _build_ui():
+	# Background
+	var bg = ColorRect.new()
+	bg.color = Color(0.15, 0.1, 0.2)
+	bg.size = Vector2(_screen_width, _screen_height)
+	add_child(bg)
+
+	# Title
+	var title = Label.new()
+	title.text = "SPELLING BEE"
+	title.position = Vector2(_screen_width / 2.0 - 80, 10)
+	title.add_theme_font_size_override("font_size", 28)
+	title.add_theme_color_override("font_color", Color(1.0, 0.85, 0.2))
+	add_child(title)
+
+	# Time display
+	_time_label = Label.new()
+	_time_label.position = Vector2(15, 15)
+	_time_label.add_theme_font_size_override("font_size", 20)
+	add_child(_time_label)
+
+	# Score display
+	_score_label = Label.new()
+	_score_label.position = Vector2(_screen_width - 250, 15)
+	_score_label.add_theme_font_size_override("font_size", 20)
+	_score_label.add_theme_color_override("font_color", Color.YELLOW)
+	add_child(_score_label)
+
+	# Prompt
+	_prompt_label = Label.new()
+	_prompt_label.position = Vector2(_screen_width / 2.0 - 200, 100)
+	_prompt_label.add_theme_font_size_override("font_size", 24)
+	_prompt_label.add_theme_color_override("font_color", Color(0.8, 0.8, 1.0))
+	_prompt_label.visible = false
+	add_child(_prompt_label)
+
+	# Choice labels
+	for i in range(4):
+		var choice = Label.new()
+		choice.position = Vector2(_screen_width / 2.0 - 120, 180 + i * 55)
+		choice.add_theme_font_size_override("font_size", 26)
+		choice.visible = false
+		add_child(choice)
+		_choices_labels.append(choice)
+
+	# Feedback
+	_feedback_label = Label.new()
+	_feedback_label.position = Vector2(_screen_width / 2.0 - 180, 420)
+	_feedback_label.add_theme_font_size_override("font_size", 18)
+	add_child(_feedback_label)
+
+	# Info
+	_info_label = Label.new()
+	_info_label.position = Vector2(15, _screen_height - 30)
+	_info_label.add_theme_font_size_override("font_size", 12)
+	_info_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	add_child(_info_label)
+
+	# Difficulty selector
+	_difficulty_label = Label.new()
+	_difficulty_label.position = Vector2(300, 200)
+	_difficulty_label.add_theme_font_size_override("font_size", 18)
+	add_child(_difficulty_label)
+
+	# Result (hidden)
+	_result_label = Label.new()
+	_result_label.position = Vector2(_screen_width / 2.0 - 150, _screen_height / 2.0 - 80)
+	_result_label.add_theme_font_size_override("font_size", 22)
+	_result_label.visible = false
+	add_child(_result_label)
+
+func _show_difficulty_select():
+	selecting_difficulty = true
+	_update_difficulty_display()
+	_info_label.text = "UP/DOWN: choose difficulty | SPACE: start | ESC: back to hub"
+
+func _update_difficulty_display():
+	var lines = ""
+	var options = ["Easy (simple words)", "Medium (everyday words)", "Hard (challenge words)"]
+	for i in range(options.size()):
+		var prefix = "> " if i == difficulty else "  "
+		lines += prefix + options[i] + "\n"
+	_difficulty_label.text = "Choose Difficulty:\n\n" + lines
+
+func _start_game():
+	selecting_difficulty = false
+	_difficulty_label.text = ""
+	_game_active = true
+	_time_remaining = GAME_DURATION
+	_correct_count = 0
+	_wrong_count = 0
+	_coins_earned = 0
+	_used_words.clear()
+	_waiting_next = false
+
+	_prompt_label.visible = true
+	for label in _choices_labels:
+		label.visible = true
+	_result_label.visible = false
+
+	_info_label.text = "UP/DOWN: select answer | SPACE: confirm | ESC: back"
+	_generate_question()
+	_update_ui()
+
+func _get_word_list() -> Array:
+	match difficulty:
+		0: return WORDS_EASY
+		1: return WORDS_MEDIUM
+		2: return WORDS_HARD
+		_: return WORDS_EASY
+
+func _generate_question():
+	var word_list = _get_word_list()
+
+	# Avoid repeats within session
+	var available: Array = []
+	for entry in word_list:
+		if entry["word"] not in _used_words:
+			available.append(entry)
+
+	# If all used, reset
+	if available.size() == 0:
+		_used_words.clear()
+		available = word_list.duplicate()
+
+	var entry = available[randi() % available.size()]
+	_current_word = entry["word"]
+	_used_words.append(_current_word)
+
+	# Build choices: correct + 3 wrong, shuffled
+	_choices = [_current_word]
+	for w in entry["wrong"]:
+		_choices.append(w)
+	_choices.shuffle()
+	_selected_choice = 0
+
+	_prompt_label.text = "Which spelling is correct?"
+	_draw_choices()
+
+func _draw_choices():
+	for i in range(4):
+		if i < _choices.size():
+			var prefix = "> " if i == _selected_choice else "  "
+			_choices_labels[i].text = prefix + _choices[i]
+			if i == _selected_choice:
+				_choices_labels[i].add_theme_color_override("font_color", Color.GOLD)
+			else:
+				_choices_labels[i].add_theme_color_override("font_color", Color.WHITE)
+			_choices_labels[i].visible = true
+		else:
+			_choices_labels[i].visible = false
+
+func _submit_answer():
+	_waiting_next = true
+
+	if _choices[_selected_choice] == _current_word:
+		_correct_count += 1
+		_coins_earned += 3
+		game_manager.modify_coins(3)
+		if audio_manager:
+			audio_manager.play_sfx("correct")
+		_feedback_label.text = "Correct! '%s' is right!" % _current_word
+		_feedback_label.add_theme_color_override("font_color", Color(0.3, 1.0, 0.3))
+	else:
+		_wrong_count += 1
+		if audio_manager:
+			audio_manager.play_sfx("wrong")
+		_feedback_label.text = "Oops! The correct spelling is '%s'" % _current_word
+		_feedback_label.add_theme_color_override("font_color", Color(1.0, 0.5, 0.3))
+
+	_update_ui()
+
+	# Auto-advance after 1.2 seconds
+	get_tree().create_timer(1.2).timeout.connect(_next_question)
+
+func _next_question():
+	if not _game_active:
+		return
+	_waiting_next = false
+	_feedback_label.text = ""
+	_generate_question()
+
+func _update_ui():
+	_time_label.text = "Time: %d" % ceili(_time_remaining)
+	_score_label.text = "Correct: %d | Coins: +%d" % [_correct_count, _coins_earned]
+
+func _end_game():
+	_game_active = false
+	_waiting_next = false
+
+	if _active_pet_id >= 0 and _correct_count > 0:
+		game_manager.modify_stat(_active_pet_id, "happiness", _correct_count * 2)
+		game_manager.add_xp(_active_pet_id, _correct_count * 5)
+
+	var achievement_mgr = get_tree().root.get_node_or_null("AchievementManager")
+	if achievement_mgr:
+		achievement_mgr.check_spelling_score(_correct_count, difficulty == 2)
+		achievement_mgr.check_all()
+
+	_prompt_label.visible = false
+	for label in _choices_labels:
+		label.visible = false
+	_feedback_label.text = ""
+
+	var xp_bonus = _correct_count * 5
+	_result_label.text = "TIME'S UP!\n\nCorrect: %d\nWrong: %d\nCoins earned: %d\nXP bonus: +%d\n\nPress ESC to return to Hub" % [
+		_correct_count, _wrong_count, max(0, _coins_earned), xp_bonus
+	]
+	_result_label.visible = true
+
+func _process(delta: float):
+	if not _game_active:
+		return
+
+	_time_remaining -= delta
+	if _time_remaining <= 0:
+		_end_game()
+		return
+
+	_update_ui()
+
+func _go_back():
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/Main.tscn")
+
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
+			_go_back()
+			return
+
+		# Manual save
+		if event.keycode == KEY_S and event.ctrl_pressed:
+			var save_manager = get_tree().root.get_node_or_null("SaveManager")
+			if save_manager:
+				save_manager.save_game()
+			return
+
+		if selecting_difficulty:
+			if event.keycode == KEY_UP:
+				difficulty = max(0, difficulty - 1)
+				_update_difficulty_display()
+				if audio_manager:
+					audio_manager.play_sfx("menu_navigate")
+			elif event.keycode == KEY_DOWN:
+				difficulty = min(2, difficulty + 1)
+				_update_difficulty_display()
+				if audio_manager:
+					audio_manager.play_sfx("menu_navigate")
+			elif event.keycode == KEY_SPACE:
+				if audio_manager:
+					audio_manager.play_sfx("menu_select")
+				_start_game()
+			return
+
+		if not _game_active or _waiting_next:
+			return
+
+		if event.keycode == KEY_UP:
+			_selected_choice = max(0, _selected_choice - 1)
+			_draw_choices()
+		elif event.keycode == KEY_DOWN:
+			_selected_choice = min(_choices.size() - 1, _selected_choice + 1)
+			_draw_choices()
+		elif event.keycode == KEY_SPACE:
+			_submit_answer()

--- a/scripts/SudokuGame.gd
+++ b/scripts/SudokuGame.gd
@@ -1,0 +1,357 @@
+extends Node2D
+
+# 3x3 Sudoku — fill grid so each row and column has 1, 2, 3
+# Arrow keys to navigate, 1/2/3 to fill, H for hint, Backspace to clear
+
+var game_manager
+var audio_manager
+
+# Grid state
+var _solution: Array = []
+var _puzzle: Array = []
+var _player_grid: Array = []
+var _locked: Array = []
+
+var cursor_x: int = 0
+var cursor_y: int = 0
+var _game_active: bool = false
+var _puzzles_completed: int = 0
+var _coins_earned: int = 0
+var _hints_used: int = 0
+var _total_hints_session: int = 0
+
+# UI
+var _status_label: Label
+var _info_label: Label
+var _feedback_label: Label
+var _feedback_timer: float = 0.0
+
+var _screen_width: float = 1152.0
+var _screen_height: float = 648.0
+
+# Visual constants
+const CELL_SIZE: float = 100.0
+const CELL_GAP: float = 6.0
+
+func _ready():
+	game_manager = get_tree().root.get_node("GameManager")
+	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+
+	var viewport_size = get_viewport().get_visible_rect().size
+	if viewport_size.x > 0:
+		_screen_width = viewport_size.x
+		_screen_height = viewport_size.y
+
+	_build_ui()
+	_generate_puzzle()
+	_draw_grid()
+
+func _build_ui():
+	# Background
+	var bg = ColorRect.new()
+	bg.color = Color(0.12, 0.12, 0.2)
+	bg.size = Vector2(_screen_width, _screen_height)
+	add_child(bg)
+
+	# Title
+	var title = Label.new()
+	title.text = "SUDOKU PUZZLE (3x3)"
+	title.position = Vector2(15, 10)
+	title.add_theme_font_size_override("font_size", 26)
+	title.add_theme_color_override("font_color", Color(0.4, 0.8, 1.0))
+	add_child(title)
+
+	# Status
+	_status_label = Label.new()
+	_status_label.position = Vector2(15, 45)
+	_status_label.add_theme_font_size_override("font_size", 16)
+	_status_label.add_theme_color_override("font_color", Color.YELLOW)
+	add_child(_status_label)
+
+	# Info
+	_info_label = Label.new()
+	_info_label.position = Vector2(15, _screen_height - 35)
+	_info_label.add_theme_font_size_override("font_size", 12)
+	_info_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	_info_label.text = "Arrows: move | 1-3: place number | Backspace: clear | H: hint | SPACE: next puzzle | ESC: back"
+	add_child(_info_label)
+
+	# Feedback
+	_feedback_label = Label.new()
+	_feedback_label.position = Vector2(15, 75)
+	_feedback_label.add_theme_font_size_override("font_size", 16)
+	add_child(_feedback_label)
+
+	_update_status()
+
+func _update_status():
+	_status_label.text = "Puzzles: %d | Coins: +%d | Hints: %d" % [_puzzles_completed, _coins_earned, _hints_used]
+
+func _generate_puzzle():
+	_game_active = true
+	_hints_used = 0
+
+	# Generate a valid 3x3 Latin square
+	var row1 = [1, 2, 3]
+	row1.shuffle()
+
+	var valid_row2s = _get_valid_rows(row1, [])
+	var row2 = valid_row2s[randi() % valid_row2s.size()]
+
+	var valid_row3s = _get_valid_rows(row1, row2)
+	var row3 = valid_row3s[0]
+
+	_solution = [row1.duplicate(), row2.duplicate(), row3.duplicate()]
+
+	# Remove some cells (leave 3-5 given out of 9)
+	var num_given = randi_range(3, 5)
+	_puzzle = []
+	_player_grid = []
+	_locked = []
+
+	var all_positions: Array = []
+	for r in range(3):
+		for c in range(3):
+			all_positions.append(Vector2i(r, c))
+	all_positions.shuffle()
+
+	for r in range(3):
+		_puzzle.append([0, 0, 0])
+		_player_grid.append([0, 0, 0])
+		_locked.append([false, false, false])
+
+	for i in range(num_given):
+		var pos = all_positions[i]
+		_puzzle[pos.x][pos.y] = _solution[pos.x][pos.y]
+		_player_grid[pos.x][pos.y] = _solution[pos.x][pos.y]
+		_locked[pos.x][pos.y] = true
+
+	cursor_x = 0
+	cursor_y = 0
+
+func _get_valid_rows(row1: Array, row2: Array) -> Array:
+	var perms = [[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]]
+	var valid: Array = []
+	for perm in perms:
+		var ok = true
+		for c in range(3):
+			if perm[c] == row1[c]:
+				ok = false
+				break
+			if row2.size() > 0 and perm[c] == row2[c]:
+				ok = false
+				break
+		if ok:
+			valid.append(perm)
+	return valid
+
+func _check_win() -> bool:
+	for r in range(3):
+		for c in range(3):
+			if _player_grid[r][c] != _solution[r][c]:
+				return false
+	return true
+
+func _validate_placement(row: int, col: int, value: int) -> bool:
+	for c in range(3):
+		if c != col and _player_grid[row][c] == value:
+			return false
+	for r in range(3):
+		if r != row and _player_grid[r][col] == value:
+			return false
+	return true
+
+func _give_hint():
+	# Find an empty cell and reveal it
+	for r in range(3):
+		for c in range(3):
+			if not _locked[r][c] and _player_grid[r][c] != _solution[r][c]:
+				_player_grid[r][c] = _solution[r][c]
+				_locked[r][c] = true
+				_hints_used += 1
+				_total_hints_session += 1
+				_show_feedback("Hint! Cell (%d,%d) = %d" % [r + 1, c + 1, _solution[r][c]])
+				if audio_manager:
+					audio_manager.play_sfx("menu_select")
+				_draw_grid()
+				_update_status()
+				if _check_win():
+					_puzzle_complete()
+				return
+	_show_feedback("No empty cells to hint!")
+
+func _puzzle_complete():
+	_game_active = false
+	_puzzles_completed += 1
+	var reward = 15 - (_hints_used * 3)
+	reward = max(5, reward)
+	_coins_earned += reward
+	game_manager.modify_coins(reward)
+
+	for pet_id in game_manager.get_all_pets().keys():
+		game_manager.modify_stat(pet_id, "happiness", 3)
+		game_manager.add_xp(pet_id, 8)
+
+	if audio_manager:
+		audio_manager.play_sfx("win")
+
+	var achievement_mgr = get_tree().root.get_node_or_null("AchievementManager")
+	if achievement_mgr:
+		achievement_mgr.check_sudoku_complete(_puzzles_completed, _hints_used)
+		achievement_mgr.check_all()
+
+	_show_feedback("SOLVED! +%d coins! SPACE for next puzzle, ESC to exit." % reward)
+	_update_status()
+
+func _show_feedback(msg: String):
+	_feedback_label.text = msg
+	_feedback_timer = 3.0
+
+func _draw_grid():
+	# Remove old grid visuals
+	for child in get_children():
+		if child.is_in_group("grid_visual"):
+			child.queue_free()
+
+	var grid_offset_x = (_screen_width - 3 * (CELL_SIZE + CELL_GAP)) / 2.0
+	var grid_offset_y = 130.0
+
+	for row in range(3):
+		for col in range(3):
+			var cell_x = grid_offset_x + col * (CELL_SIZE + CELL_GAP)
+			var cell_y = grid_offset_y + row * (CELL_SIZE + CELL_GAP)
+
+			# Cursor highlight
+			if row == cursor_y and col == cursor_x and _game_active:
+				var border = ColorRect.new()
+				border.size = Vector2(CELL_SIZE + 6, CELL_SIZE + 6)
+				border.position = Vector2(cell_x - 3, cell_y - 3)
+				border.color = Color.GOLD
+				border.add_to_group("grid_visual")
+				add_child(border)
+
+			# Cell background
+			var cell = ColorRect.new()
+			cell.size = Vector2(CELL_SIZE, CELL_SIZE)
+			cell.position = Vector2(cell_x, cell_y)
+			cell.add_to_group("grid_visual")
+
+			var value = _player_grid[row][col]
+			var is_conflict = value > 0 and not _validate_placement(row, col, value) and not _locked[row][col]
+
+			if _locked[row][col]:
+				cell.color = Color(0.25, 0.25, 0.4)  # given cells
+			elif is_conflict:
+				cell.color = Color(0.5, 0.15, 0.15)  # conflict
+			elif value > 0:
+				cell.color = Color(0.2, 0.35, 0.2)  # player filled
+			else:
+				cell.color = Color(0.18, 0.18, 0.28)  # empty
+
+			add_child(cell)
+
+			# Number display
+			if value > 0:
+				var num_label = Label.new()
+				num_label.text = str(value)
+				num_label.position = Vector2(cell_x + CELL_SIZE / 2 - 12, cell_y + CELL_SIZE / 2 - 18)
+				num_label.add_theme_font_size_override("font_size", 36)
+				num_label.add_to_group("grid_visual")
+
+				if _locked[row][col]:
+					num_label.add_theme_color_override("font_color", Color.WHITE)
+				elif is_conflict:
+					num_label.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
+				else:
+					num_label.add_theme_color_override("font_color", Color(0.5, 1.0, 0.5))
+
+				num_label.z_index = 1
+				add_child(num_label)
+
+	# Draw row/column labels
+	for i in range(3):
+		var row_label = Label.new()
+		row_label.text = "Row %d" % (i + 1)
+		row_label.position = Vector2(grid_offset_x - 65, grid_offset_y + i * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2 - 10)
+		row_label.add_theme_font_size_override("font_size", 12)
+		row_label.add_theme_color_override("font_color", Color(0.5, 0.5, 0.6))
+		row_label.add_to_group("grid_visual")
+		add_child(row_label)
+
+func _process(delta: float):
+	if _feedback_timer > 0:
+		_feedback_timer -= delta
+		if _feedback_timer <= 0:
+			_feedback_label.text = ""
+
+func _go_back():
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/Main.tscn")
+
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
+			_go_back()
+			return
+
+		# Manual save
+		if event.keycode == KEY_S and event.ctrl_pressed:
+			var save_manager = get_tree().root.get_node_or_null("SaveManager")
+			if save_manager:
+				save_manager.save_game()
+			_show_feedback("Game saved!")
+			return
+
+		if not _game_active:
+			if event.keycode == KEY_SPACE:
+				_generate_puzzle()
+				_draw_grid()
+				_update_status()
+			return
+
+		# Navigation
+		if event.keycode == KEY_UP:
+			cursor_y = max(0, cursor_y - 1)
+			_draw_grid()
+		elif event.keycode == KEY_DOWN:
+			cursor_y = min(2, cursor_y + 1)
+			_draw_grid()
+		elif event.keycode == KEY_LEFT:
+			cursor_x = max(0, cursor_x - 1)
+			_draw_grid()
+		elif event.keycode == KEY_RIGHT:
+			cursor_x = min(2, cursor_x + 1)
+			_draw_grid()
+
+		# Number entry
+		elif event.keycode in [KEY_1, KEY_2, KEY_3]:
+			if _locked[cursor_y][cursor_x]:
+				_show_feedback("That cell is locked!")
+				return
+			var num = event.keycode - KEY_1 + 1
+			_player_grid[cursor_y][cursor_x] = num
+
+			if not _validate_placement(cursor_y, cursor_x, num):
+				_show_feedback("Conflict! %d already in this row or column." % num)
+				if audio_manager:
+					audio_manager.play_sfx("wrong")
+			else:
+				if audio_manager:
+					audio_manager.play_sfx("menu_select")
+
+			_draw_grid()
+
+			if _check_win():
+				_puzzle_complete()
+
+		# Clear cell
+		elif event.keycode == KEY_BACKSPACE or event.keycode == KEY_DELETE:
+			if not _locked[cursor_y][cursor_x]:
+				_player_grid[cursor_y][cursor_x] = 0
+				_draw_grid()
+
+		# Hint
+		elif event.keycode == KEY_H:
+			_give_hint()

--- a/scripts/VetClinic.gd
+++ b/scripts/VetClinic.gd
@@ -171,6 +171,15 @@ func _input(event):
 			_go_back()
 			return
 
+		# Manual save
+		if event.keycode == KEY_S and event.ctrl_pressed:
+			var save_manager = get_tree().root.get_node_or_null("SaveManager")
+			if save_manager:
+				save_manager.save_game()
+			var status_label = get_node("UI/StatusLabel")
+			status_label.text = "Game saved!"
+			return
+
 		if event.keycode == KEY_H:
 			_heal_pet()
 			return


### PR DESCRIPTION
## Summary
- **Weather/Sky**: Sun, moon, 3D puffy cloud clusters, rain particle system with light dimming
- **Dragon overhaul**: Wings, back spines, head horns, snout, wing flap animation
- **New pet types**: Dog-o-corn (floppy ears, wagging tail, snout) and Cat-o-corn (pointed ears, whiskers, swishing tail)
- **Koala riders**: 20% of pets spawn with a koala companion riding on their back
- **WASD walking**: Free camera movement on Island
- **Math Challenge**: Times tables mini-game with 3 difficulties and streak bonuses
- **Sudoku Puzzle**: 3x3 Latin square puzzles with hints and conflict highlighting
- **Spelling Bee**: 50+ words across 3 difficulty tiers, multiple choice
- **Pet renaming**: Press X on Island to rename selected pet
- **Manual save**: Ctrl+S in all scenes + CSV pet data export
- **UI fix**: Island text no longer overlaps with many pets
- **Exploit fix**: P+R coin cheat blocked with action cooldown
- **Audio**: Softer default volume, new correct/wrong/bark/meow sounds
- **Pegasus**: No longer has a horn (lore accuracy)
- **10 new achievements**: Dog Lover, Cat Lover, Animal Ark, Koala Friend, Math Whiz, Puzzle Solver, No Hints Needed, Spelling Bee, Word Master
- **Updated egg probabilities** for 6 pet types

## Test plan
- [ ] Verify new pet types hatch from eggs and display correctly
- [ ] Verify dragon has wings, spines, and horns
- [ ] Verify koala appears on ~20% of new pets
- [ ] Test WASD camera movement on Island
- [ ] Test Math Challenge at all 3 difficulties
- [ ] Test Sudoku puzzle generation, hints, and validation
- [ ] Test Spelling Bee at all 3 difficulties
- [ ] Test pet renaming (X key) on Island
- [ ] Test Ctrl+S manual save in all scenes
- [ ] Verify rain events occur and dim lighting
- [ ] Verify sun/moon orbit with day/night cycle
- [ ] Verify P+R exploit is blocked by cooldown
- [ ] Verify save/load preserves new pet types and koala riders
- [ ] Verify all 10 new achievements can unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)