### PR TITLE
feat: egg rewards, pet visuals, profile screen, game persistence (v1.4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ unicorn, pegasus, dragon, alicorn, dogocorn, catocorn
 | `MathGame.tscn` | `MathGame.gd` | Math challenge (10 levels: add/sub/mul/div/mixed, advance on 8+ correct) |
 | `SudokuGame.tscn` | `SudokuGame.gd` | Sudoku (6 levels: 3x3 and 4x4, advance without hints) |
 | `SpellingGame.tscn` | `SpellingGame.gd` | Spelling bee (10 levels: tiny to expert words, advance on 6+ correct) |
+| `PetProfile.tscn` | `PetProfile.gd` | Pet inspect screen with 3D model, stats, rename |
 | `AchievementScreen.tscn` | `AchievementScreen.gd` | Achievement gallery |
 
 ### Autoloaded Singletons
@@ -75,7 +76,10 @@ unicorn, pegasus, dragon, alicorn, dogocorn, catocorn
 UP/DOWN + SPACE to navigate, or hotkeys: Q(Island) V(Vet) G(Random Game) A(Achievements)
 
 ### Island
-WASD or Numpad 8/4/2/6 — camera movement, F — feed, P — play, R — rest, C — collect egg, X — rename pet, LEFT/RIGHT — select pet, ESC — back
+WASD or Arrow keys or Numpad 8/4/2/6 — camera movement, LEFT/RIGHT — select pet, F — feed, P — play, R — rest, E — collect egg, I — inspect pet, X — rename pet, ESC — back
+
+### Pet Profile
+X — rename pet, ESC — back to Island
 
 ### Global
 M — mute/unmute audio, Ctrl+S — manual save
@@ -89,4 +93,9 @@ M — mute/unmute audio, Ctrl+S — manual save
 - Action cooldown of 0.5s on Island prevents input exploits
 - Egg inventory max: 3 eggs, 300s hatch timer each
 - Mini-games are randomly selected (kids can't choose) — levels auto-advance on good performance
+- Completing a mini-game awards an egg (if inventory < 3) plus coins/XP
+- If player ESCs from a mini-game without finishing, they must return to that same game (tracked via `pending_game`)
 - Game levels persist in `game_levels` dict in GameManager, saved to JSON
+- Unicorns have rainbow manes/tails; pegasus have blue manes/tails and pink wings
+- Dragons have green bodies and gold heads
+- Island sky is light blue, transitions to gray during rain

--- a/scenes/PetProfile.tscn
+++ b/scenes/PetProfile.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/PetProfile.gd" id="1"]
+
+[node name="PetProfile" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -271,6 +271,10 @@ func _go_to_random_game():
 	var save_manager = get_tree().root.get_node_or_null("SaveManager")
 	if save_manager:
 		save_manager.on_scene_transition()
+	# If player escaped a game without finishing, force return to that game
+	if game_manager.pending_game != "":
+		get_tree().change_scene_to_file(game_manager.pending_game)
+		return
 	var scene_path = MINI_GAME_SCENES[randi() % MINI_GAME_SCENES.size()]
 	get_tree().change_scene_to_file(scene_path)
 
@@ -283,10 +287,11 @@ func _go_to_achievements():
 func _update_menu_display():
 	if _menu_label == null:
 		return
+	var game_option = "Continue Game! (G)" if game_manager.pending_game != "" else "Play a Game! (G)  [random surprise]"
 	var options = [
 		"Visit Island (Q)",
 		"Visit Vet (V)",
-		"Play a Game! (G)  [random surprise]",
+		game_option,
 		"Achievements (A)"
 	]
 	var text = ""

--- a/scripts/MathGame.gd
+++ b/scripts/MathGame.gd
@@ -62,6 +62,7 @@ const LEVEL_NAMES: Array = [
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+	game_manager.pending_game = "res://scenes/MathGame.tscn"
 
 	_level = game_manager.get_game_level("math")
 
@@ -329,6 +330,16 @@ func _end_game():
 		result_text += "\n\nLEVEL UP! Now Level %d: %s" % [_level, LEVEL_NAMES[_level]]
 	elif _correct_count < ADVANCE_THRESHOLD:
 		result_text += "\n\nNeed %d correct to advance (got %d)" % [ADVANCE_THRESHOLD, _correct_count]
+
+	# Award egg for completing the game
+	var egg_got = game_manager.collect_egg()
+	if egg_got:
+		result_text += "\n+1 Egg!"
+	else:
+		result_text += "\nEgg inventory full!"
+
+	# Clear pending game — player completed it
+	game_manager.pending_game = ""
 
 	result_text += "\n\nPress ESC to return to Hub"
 	_result_label.text = result_text

--- a/scripts/MemoryGame.gd
+++ b/scripts/MemoryGame.gd
@@ -70,6 +70,7 @@ const LEVEL_CONFIG: Array = [
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+	game_manager.pending_game = "res://scenes/MemoryGame.tscn"
 
 	_level = game_manager.get_game_level("memory")
 
@@ -277,7 +278,14 @@ func _game_won():
 		leveled_up = true
 		_level = new_level
 
-	var msg = "You matched them all! +%d bonus coins!" % bonus
+	# Award egg for completing the game
+	var egg_got = game_manager.collect_egg()
+	var egg_msg = " +1 Egg!" if egg_got else " Egg inventory full!"
+
+	# Clear pending game — player completed it
+	game_manager.pending_game = ""
+
+	var msg = "You matched them all! +%d bonus coins!%s" % [bonus, egg_msg]
 	if leveled_up:
 		msg += " LEVEL UP! Now Level %d: %s" % [_level, LEVEL_NAMES[_level]]
 	msg += " ESC to exit."

--- a/scripts/MiniGame.gd
+++ b/scripts/MiniGame.gd
@@ -60,6 +60,7 @@ var _active_pet_id: int = -1
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+	game_manager.pending_game = "res://scenes/MiniGame.tscn"
 
 	_level = game_manager.get_game_level("treat_catch")
 
@@ -295,6 +296,16 @@ func _end_game():
 		result_text += "\n\nLEVEL UP! Now Level %d: %s" % [_level, LEVEL_NAMES[_level]]
 	elif _score < ADVANCE_THRESHOLD:
 		result_text += "\n\nNeed score %d to advance (got %d)" % [ADVANCE_THRESHOLD, _score]
+
+	# Award egg for completing the game
+	var egg_got = game_manager.collect_egg()
+	if egg_got:
+		result_text += "\n+1 Egg!"
+	else:
+		result_text += "\nEgg inventory full!"
+
+	# Clear pending game — player completed it
+	game_manager.pending_game = ""
 
 	result_text += "\n\nPress ESC to return to Hub"
 	_result_label.text = result_text

--- a/scripts/PetProfile.gd
+++ b/scripts/PetProfile.gd
@@ -1,0 +1,350 @@
+extends Control
+
+# Pet Profile / Inspect screen — shows close-up 3D model with stats
+# Accessed from Island by pressing I on the selected pet
+
+var game_manager
+var audio_manager
+var _pet_id: int = -1
+
+# UI elements
+var _name_label: Label
+var _type_label: Label
+var _level_label: Label
+var _xp_label: Label
+var _health_bar: ProgressBar
+var _happiness_bar: ProgressBar
+var _hunger_bar: ProgressBar
+var _energy_bar: ProgressBar
+var _health_label: Label
+var _happiness_label: Label
+var _hunger_label: Label
+var _energy_label: Label
+var _koala_label: Label
+var _instructions_label: Label
+var _feedback_label: Label
+
+# 3D pet display
+var _viewport: SubViewport
+var _pet_node: Pet
+var _pet_rotation: float = 0.0
+
+# Rename mode
+var _renaming: bool = false
+var _rename_buffer: String = ""
+var _rename_label: Label
+
+func _ready():
+	game_manager = get_tree().root.get_node("GameManager")
+	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+	_pet_id = game_manager.inspecting_pet_id
+
+	if _pet_id < 0 or game_manager.get_pet_info(_pet_id) == null:
+		# No valid pet — go back
+		get_tree().change_scene_to_file("res://scenes/Island.tscn")
+		return
+
+	_create_3d_viewport()
+	_create_ui()
+	_update_stats()
+
+func _create_3d_viewport():
+	# SubViewport for 3D pet rendering
+	var container = SubViewportContainer.new()
+	container.position = Vector2(50, 80)
+	container.size = Vector2(400, 400)
+	container.stretch = true
+	add_child(container)
+
+	_viewport = SubViewport.new()
+	_viewport.size = Vector2i(400, 400)
+	_viewport.transparent_bg = true
+	_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
+	container.add_child(_viewport)
+
+	# Camera for the pet view
+	var camera = Camera3D.new()
+	camera.position = Vector3(0, 0.5, 2.5)
+	camera.look_at(Vector3(0, 0.2, 0), Vector3.UP)
+	_viewport.add_child(camera)
+
+	# Light
+	var light = DirectionalLight3D.new()
+	light.rotation.x = -PI / 4
+	light.rotation.y = -PI / 6
+	light.light_energy = 1.2
+	_viewport.add_child(light)
+
+	# Ambient light
+	var env = Environment.new()
+	env.background_mode = Environment.BG_COLOR
+	env.background_color = Color(0.2, 0.15, 0.3)
+	env.ambient_light_source = Environment.AMBIENT_SOURCE_COLOR
+	env.ambient_light_color = Color.WHITE
+	env.ambient_light_energy = 0.6
+	var world_env = WorldEnvironment.new()
+	world_env.environment = env
+	_viewport.add_child(world_env)
+
+	# Pet model
+	var info = game_manager.get_pet_info(_pet_id)
+	_pet_node = Pet.new()
+	_pet_node.pet_id = _pet_id
+	_pet_node.pet_name = info["name"]
+	_pet_node.pet_type = info["type"]
+	_pet_node.position = Vector3(0, 0, 0)
+	_viewport.add_child(_pet_node)
+
+func _create_ui():
+	var info = game_manager.get_pet_info(_pet_id)
+
+	# Background
+	var bg = ColorRect.new()
+	bg.color = Color(0.1, 0.08, 0.18)
+	bg.anchor_right = 1.0
+	bg.anchor_bottom = 1.0
+	bg.z_index = -1
+	add_child(bg)
+
+	# Title
+	var title = Label.new()
+	title.text = "PET PROFILE"
+	title.position = Vector2(50, 15)
+	title.add_theme_font_size_override("font_size", 28)
+	title.add_theme_color_override("font_color", Color(0.9, 0.8, 1.0))
+	add_child(title)
+
+	# Stats panel — right side
+	var stats_x = 500.0
+	var y = 100.0
+	var line_h = 36.0
+
+	# Name
+	_name_label = Label.new()
+	_name_label.position = Vector2(stats_x, y)
+	_name_label.add_theme_font_size_override("font_size", 24)
+	_name_label.add_theme_color_override("font_color", Color.WHITE)
+	add_child(_name_label)
+	y += line_h + 4
+
+	# Type
+	_type_label = Label.new()
+	_type_label.position = Vector2(stats_x, y)
+	_type_label.add_theme_font_size_override("font_size", 16)
+	_type_label.add_theme_color_override("font_color", Color(0.7, 0.7, 0.8))
+	add_child(_type_label)
+	y += line_h
+
+	# Level + XP
+	_level_label = Label.new()
+	_level_label.position = Vector2(stats_x, y)
+	_level_label.add_theme_font_size_override("font_size", 18)
+	_level_label.add_theme_color_override("font_color", Color.GOLD)
+	add_child(_level_label)
+	y += line_h - 4
+
+	_xp_label = Label.new()
+	_xp_label.position = Vector2(stats_x, y)
+	_xp_label.add_theme_font_size_override("font_size", 14)
+	_xp_label.add_theme_color_override("font_color", Color(0.6, 0.7, 0.9))
+	add_child(_xp_label)
+	y += line_h + 8
+
+	# Stat bars
+	_health_bar = _create_stat_bar("Health", stats_x, y, Color(0.2, 0.8, 0.2))
+	_health_label = _health_bar.get_meta("value_label")
+	y += line_h + 8
+
+	_happiness_bar = _create_stat_bar("Happiness", stats_x, y, Color(1.0, 0.7, 0.8))
+	_happiness_label = _happiness_bar.get_meta("value_label")
+	y += line_h + 8
+
+	_hunger_bar = _create_stat_bar("Hunger", stats_x, y, Color(1.0, 0.6, 0.2))
+	_hunger_label = _hunger_bar.get_meta("value_label")
+	y += line_h + 8
+
+	_energy_bar = _create_stat_bar("Energy", stats_x, y, Color(0.4, 0.6, 1.0))
+	_energy_label = _energy_bar.get_meta("value_label")
+	y += line_h + 16
+
+	# Koala status
+	_koala_label = Label.new()
+	_koala_label.position = Vector2(stats_x, y)
+	_koala_label.add_theme_font_size_override("font_size", 14)
+	add_child(_koala_label)
+	y += line_h
+
+	# Feedback label
+	_feedback_label = Label.new()
+	_feedback_label.position = Vector2(stats_x, y)
+	_feedback_label.add_theme_font_size_override("font_size", 15)
+	_feedback_label.add_theme_color_override("font_color", Color.GOLD)
+	add_child(_feedback_label)
+
+	# Instructions at bottom
+	_instructions_label = Label.new()
+	_instructions_label.text = "X: Rename | ESC: Back to Island"
+	_instructions_label.position = Vector2(50, 500)
+	_instructions_label.add_theme_font_size_override("font_size", 14)
+	_instructions_label.add_theme_color_override("font_color", Color(0.5, 0.5, 0.6))
+	add_child(_instructions_label)
+
+	# Rename label (hidden by default)
+	_rename_label = Label.new()
+	_rename_label.position = Vector2(stats_x, 480)
+	_rename_label.add_theme_font_size_override("font_size", 18)
+	_rename_label.add_theme_color_override("font_color", Color(0.4, 1.0, 0.4))
+	_rename_label.visible = false
+	add_child(_rename_label)
+
+func _create_stat_bar(stat_name: String, x: float, y: float, color: Color) -> ProgressBar:
+	var label = Label.new()
+	label.text = stat_name
+	label.position = Vector2(x, y)
+	label.add_theme_font_size_override("font_size", 14)
+	label.add_theme_color_override("font_color", Color(0.8, 0.8, 0.8))
+	add_child(label)
+
+	var bar = ProgressBar.new()
+	bar.position = Vector2(x + 100, y + 2)
+	bar.size = Vector2(200, 18)
+	bar.min_value = 0
+	bar.max_value = 100
+	bar.show_percentage = false
+
+	# Style the bar fill color
+	var fill_style = StyleBoxFlat.new()
+	fill_style.bg_color = color
+	fill_style.corner_radius_top_left = 4
+	fill_style.corner_radius_top_right = 4
+	fill_style.corner_radius_bottom_left = 4
+	fill_style.corner_radius_bottom_right = 4
+	bar.add_theme_stylebox_override("fill", fill_style)
+
+	var bg_style = StyleBoxFlat.new()
+	bg_style.bg_color = Color(0.2, 0.2, 0.25)
+	bg_style.corner_radius_top_left = 4
+	bg_style.corner_radius_top_right = 4
+	bg_style.corner_radius_bottom_left = 4
+	bg_style.corner_radius_bottom_right = 4
+	bar.add_theme_stylebox_override("background", bg_style)
+
+	add_child(bar)
+
+	# Value label after bar
+	var val_label = Label.new()
+	val_label.position = Vector2(x + 310, y)
+	val_label.add_theme_font_size_override("font_size", 14)
+	val_label.add_theme_color_override("font_color", color)
+	add_child(val_label)
+
+	bar.set_meta("value_label", val_label)
+	return bar
+
+func _update_stats():
+	var info = game_manager.get_pet_info(_pet_id)
+	if info == null:
+		return
+
+	var cap = game_manager.get_stat_cap(_pet_id)
+	var xp_info = game_manager.get_xp_progress(_pet_id)
+	var mood = game_manager.get_pet_mood(_pet_id)
+	var emoji = game_manager.get_mood_emoji(_pet_id)
+
+	_name_label.text = "%s %s" % [info["name"], emoji]
+	_type_label.text = "%s — Mood: %s" % [info["type"].capitalize(), mood.capitalize()]
+	_level_label.text = "Level %d" % info["level"]
+
+	if xp_info["next"] > 0:
+		_xp_label.text = "XP: %d / %d" % [xp_info["current"], xp_info["next"]]
+	else:
+		_xp_label.text = "XP: MAX"
+
+	_health_bar.max_value = cap
+	_health_bar.value = info["health"]
+	_health_label.text = "%d/%d" % [info["health"], cap]
+
+	_happiness_bar.max_value = cap
+	_happiness_bar.value = info["happiness"]
+	_happiness_label.text = "%d/%d" % [info["happiness"], cap]
+
+	_hunger_bar.max_value = cap
+	_hunger_bar.value = info["hunger"]
+	_hunger_label.text = "%d/%d" % [info["hunger"], cap]
+
+	_energy_bar.max_value = cap
+	_energy_bar.value = info["energy"]
+	_energy_label.text = "%d/%d" % [info["energy"], cap]
+
+	if info.get("has_koala", false):
+		_koala_label.text = "Koala Rider!"
+		_koala_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	else:
+		_koala_label.text = ""
+
+func _process(delta: float):
+	# Slowly rotate the pet model
+	if _pet_node:
+		_pet_rotation += delta * 0.5
+		_pet_node.rotation.y = _pet_rotation
+
+	# Refresh stats in case of decay
+	_update_stats()
+
+func _start_rename():
+	_renaming = true
+	_rename_buffer = ""
+	_rename_label.visible = true
+	_rename_label.text = "New name: _\n(Type name, ENTER to confirm, ESC to cancel)"
+
+func _finish_rename():
+	if _rename_buffer.length() > 0:
+		game_manager.pets[_pet_id]["name"] = _rename_buffer
+		if _pet_node:
+			_pet_node.pet_name = _rename_buffer
+		_feedback_label.text = "Renamed to '%s'!" % _rename_buffer
+	_renaming = false
+	_rename_label.visible = false
+	_rename_buffer = ""
+
+func _cancel_rename():
+	_renaming = false
+	_rename_label.visible = false
+	_rename_buffer = ""
+
+func _go_back():
+	game_manager.inspecting_pet_id = -1
+	var save_manager = get_tree().root.get_node_or_null("SaveManager")
+	if save_manager:
+		save_manager.on_scene_transition()
+	get_tree().change_scene_to_file("res://scenes/Island.tscn")
+
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		# Rename mode input handling
+		if _renaming:
+			if event.keycode == KEY_ESCAPE:
+				_cancel_rename()
+				return
+			if event.keycode == KEY_ENTER:
+				_finish_rename()
+				return
+			if event.keycode == KEY_BACKSPACE:
+				if _rename_buffer.length() > 0:
+					_rename_buffer = _rename_buffer.substr(0, _rename_buffer.length() - 1)
+				_rename_label.text = "New name: %s_\n(Type name, ENTER to confirm, ESC to cancel)" % _rename_buffer
+				return
+			if event.unicode > 0 and _rename_buffer.length() < 20:
+				var ch = char(event.unicode)
+				if ch.strip_edges() != "" or ch == " ":
+					_rename_buffer += ch
+					_rename_label.text = "New name: %s_\n(Type name, ENTER to confirm, ESC to cancel)" % _rename_buffer
+			return
+
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
+			_go_back()
+			return
+
+		if event.keycode == KEY_X:
+			_start_rename()
+			return

--- a/scripts/SaveManager.gd
+++ b/scripts/SaveManager.gd
@@ -38,6 +38,7 @@ func save_game():
 		"total_play_time": gm.total_play_time,
 		"last_login_date": gm.last_login_date,
 		"game_levels": gm.game_levels,
+		"pending_game": gm.pending_game,
 		"achievements": achievements,
 	}
 
@@ -105,6 +106,77 @@ func load_game() -> Dictionary:
 		return {}
 
 	return data
+
+func import_pets_from_csv() -> Dictionary:
+	# Fallback import: recover pets from old pets_export.csv when JSON save is missing.
+	# Supports both old format (11 columns) and any future format with extra columns.
+	# CSV header: pet_id,name,type,level,xp,health,happiness,hunger,energy,color_variant,has_koala
+	if not FileAccess.file_exists(CSV_PATH):
+		return {}
+
+	var file = FileAccess.open(CSV_PATH, FileAccess.READ)
+	if file == null:
+		return {}
+
+	var header_line = file.get_line().strip_edges()
+	if not header_line.begins_with("pet_id"):
+		file.close()
+		return {}
+
+	var headers = header_line.split(",")
+
+	var imported_pets = {}
+	var max_id = 0
+	while not file.eof_reached():
+		var line = file.get_line().strip_edges()
+		if line == "":
+			continue
+
+		var cols = line.split(",")
+		if cols.size() < 9:
+			continue  # need at least: pet_id,name,type,level,xp,health,happiness,hunger,energy
+
+		var pid = int(cols[0])
+		var pet_name = str(cols[1]).replace(";", ",")  # reverse the comma escaping
+		var pet_type = str(cols[2])
+
+		# Validate pet type
+		if pet_type not in ["unicorn", "pegasus", "dragon", "alicorn", "dogocorn", "catocorn"]:
+			continue
+
+		# CSV columns: pet_id(0),name(1),type(2),level(3),xp(4),
+		#   health(5),happiness(6),hunger(7),energy(8),color_variant(9),has_koala(10)
+		var pet = {
+			"name": pet_name,
+			"type": pet_type,
+			"level": int(cols[3]) if cols.size() > 3 else 1,
+			"xp": int(cols[4]) if cols.size() > 4 else 0,
+			"health": int(cols[5]) if cols.size() > 5 else 100,
+			"happiness": int(cols[6]) if cols.size() > 6 else 100,
+			"hunger": int(cols[7]) if cols.size() > 7 else 50,
+			"energy": int(cols[8]) if cols.size() > 8 else 100,
+			"location": "hub",
+			"color_variant": int(cols[9]) if cols.size() > 9 else 0,
+			"has_koala": str(cols[10]).to_lower() == "true" if cols.size() > 10 else false,
+		}
+
+		imported_pets[pid] = pet
+		if pid > max_id:
+			max_id = pid
+
+	file.close()
+
+	if imported_pets.is_empty():
+		return {}
+
+	# Return a minimal save-like dictionary so GameManager can load it
+	return {
+		"pets": imported_pets,
+		"next_pet_id": max_id + 1,
+		"coins": 50,
+		"total_coins_earned": 0,
+		"_imported_from_csv": true,
+	}
 
 func on_scene_transition():
 	save_game()

--- a/scripts/SpellingGame.gd
+++ b/scripts/SpellingGame.gd
@@ -195,6 +195,7 @@ var _screen_height: float = 648.0
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+	game_manager.pending_game = "res://scenes/SpellingGame.tscn"
 
 	_level = game_manager.get_game_level("spelling")
 
@@ -404,6 +405,16 @@ func _end_game():
 		result_text += "\n\nLEVEL UP! Now Level %d: %s" % [_level, LEVEL_NAMES[_level]]
 	elif _correct_count < ADVANCE_THRESHOLD:
 		result_text += "\n\nNeed %d correct to advance (got %d)" % [ADVANCE_THRESHOLD, _correct_count]
+
+	# Award egg for completing the game
+	var egg_got = game_manager.collect_egg()
+	if egg_got:
+		result_text += "\n+1 Egg!"
+	else:
+		result_text += "\nEgg inventory full!"
+
+	# Clear pending game — player completed it
+	game_manager.pending_game = ""
 
 	result_text += "\n\nPress ESC to return to Hub"
 	_result_label.text = result_text

--- a/scripts/SudokuGame.gd
+++ b/scripts/SudokuGame.gd
@@ -51,6 +51,7 @@ const LEVEL_NAMES: Array = [
 func _ready():
 	game_manager = get_tree().root.get_node("GameManager")
 	audio_manager = get_tree().root.get_node_or_null("AudioManager")
+	game_manager.pending_game = "res://scenes/SudokuGame.tscn"
 
 	_level = game_manager.get_game_level("sudoku")
 
@@ -315,7 +316,14 @@ func _puzzle_complete():
 			leveled_up = true
 			_level = new_level
 
-	var msg = "SOLVED! +%d coins!" % reward
+	# Award egg for completing the puzzle
+	var egg_got = game_manager.collect_egg()
+	var egg_msg = " +1 Egg!" if egg_got else " Egg inventory full!"
+
+	# Clear pending game — player completed it
+	game_manager.pending_game = ""
+
+	var msg = "SOLVED! +%d coins!%s" % [reward, egg_msg]
 	if leveled_up:
 		msg += " LEVEL UP! Now Level %d: %s" % [_level, LEVEL_NAMES[_level]]
 	elif _hints_used > 0:


### PR DESCRIPTION
## Summary
- Award an egg on mini-game completion (all 5 games); show "+1 Egg!" in results
- Force return to same game if player ESCs without finishing (`pending_game` tracked in save)
- Unicorn: rainbow mane/tail; Pegasus: blue mane/tail + pink wings; Dragon: green body + gold head
- Light blue sky on Island with gray overcast transition during rain (WorldEnvironment)
- Arrow key + numpad camera movement; pet selection moved to LEFT/RIGHT
- New Pet Profile screen (press I on Island) — rotating 3D model, stat bars, rename
- CSV import fallback for backward compatibility when JSON save is missing
- Updated CLAUDE.md with new controls and conventions

## Test plan
- [ ] Complete a mini-game → verify egg awarded + results text
- [ ] ESC mid-game → hub shows "Continue Game!" → G returns to same game
- [ ] Complete game → hub shows "Play a Game!" → G picks random
- [ ] Arrow keys move camera on Island
- [ ] LEFT/RIGHT select pets on Island
- [ ] Verify unicorn rainbow mane/tail, pegasus blue mane/tail + pink wings, dragon green body + gold head
- [ ] Island sky is light blue, transitions to gray during rain
- [ ] Press I on Island → Pet Profile with rotating model, stats, rename with X
- [ ] Old save file loads without errors (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)