### PR TITLE
fix: koala rider visibility, rename pet types (v1.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Godot 4.3 / GDScript 3D pet simulation game. All visuals are procedurally genera
 
 ### Pet Types (6)
 
-unicorn, pegasus, dragon, alicorn, dogocorn, catocorn
+unicorn, pegasus, dragon, alicorn, dogicorn, caticorn
 
 ~20% of pets spawn with a koala rider.
 

--- a/scripts/AchievementManager.gd
+++ b/scripts/AchievementManager.gd
@@ -78,7 +78,7 @@ func check_all():
 	# Dog Lover
 	var dog_count = 0
 	for pid in all_pets.keys():
-		if all_pets[pid]["type"] == "dogocorn":
+		if all_pets[pid]["type"] == "dogicorn":
 			dog_count += 1
 	if dog_count >= 3:
 		_try_unlock("dog_lover")
@@ -86,7 +86,7 @@ func check_all():
 	# Cat Lover
 	var cat_count = 0
 	for pid in all_pets.keys():
-		if all_pets[pid]["type"] == "catocorn":
+		if all_pets[pid]["type"] == "caticorn":
 			cat_count += 1
 	if cat_count >= 3:
 		_try_unlock("cat_lover")

--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -77,8 +77,8 @@ const COLOR_VARIANTS = {
 	"pegasus": [Color.LIGHT_GRAY, Color(0.75, 0.75, 0.75), Color(0.53, 0.81, 0.92), Color(0.73, 0.56, 0.87)],
 	"dragon": [Color(0.0, 0.6, 0.0), Color(0.0, 0.75, 0.0), Color(0.4, 0.0, 0.6), Color(1.0, 0.5, 0.0)],
 	"alicorn": [Color(0.6, 0.2, 0.8), Color(0.1, 0.1, 0.7), Color.WHITE],
-	"dogocorn": [Color(0.72, 0.53, 0.34), Color(0.95, 0.87, 0.73), Color(0.3, 0.3, 0.3), Color(1.0, 0.85, 0.6)],
-	"catocorn": [Color(0.95, 0.6, 0.2), Color(0.2, 0.2, 0.2), Color(0.85, 0.85, 0.85), Color(0.75, 0.55, 0.35)],
+	"dogicorn": [Color(0.72, 0.53, 0.34), Color(0.95, 0.87, 0.73), Color(0.3, 0.3, 0.3), Color(1.0, 0.85, 0.6)],
+	"caticorn": [Color(0.95, 0.6, 0.2), Color(0.2, 0.2, 0.2), Color(0.85, 0.85, 0.85), Color(0.75, 0.55, 0.35)],
 }
 
 func _ready():
@@ -121,9 +121,15 @@ func _load_saved_data():
 	for key in saved_pets.keys():
 		var pet_id = int(key)
 		var pet_data = saved_pets[key]
+		# Map old type names to new names
+		var loaded_type = str(pet_data.get("type", "unicorn"))
+		if loaded_type == "dogocorn":
+			loaded_type = "dogicorn"
+		elif loaded_type == "catocorn":
+			loaded_type = "caticorn"
 		pets[pet_id] = {
 			"name": str(pet_data.get("name", "Pet")),
-			"type": str(pet_data.get("type", "unicorn")),
+			"type": loaded_type,
 			"health": int(pet_data.get("health", 100)),
 			"happiness": int(pet_data.get("happiness", 100)),
 			"hunger": int(pet_data.get("hunger", 50)),
@@ -275,9 +281,9 @@ func _roll_egg_type() -> String:
 	elif roll < 0.65:
 		return "dragon"
 	elif roll < 0.77:
-		return "dogocorn"
+		return "dogicorn"
 	elif roll < 0.89:
-		return "catocorn"
+		return "caticorn"
 	else:
 		return "alicorn"
 

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -216,23 +216,26 @@ func _update_egg_display():
 
 func _spawn_starting_pets():
 	var pet_names = ["Sparkle", "Rainbow", "Cloud", "Moonlight", "Biscuit", "Whiskers"]
-	var pet_types = ["unicorn", "pegasus", "dragon", "alicorn", "dogocorn", "catocorn"]
+	var pet_types = ["unicorn", "pegasus", "dragon", "alicorn", "dogicorn", "caticorn"]
 
+	# Create pet data first (before spawning visuals)
 	for i in range(pet_names.size()):
-		var pet_id = game_manager.add_pet(pet_names[i], pet_types[i])
-		_spawn_pet_in_world(pet_id)
+		game_manager.add_pet(pet_names[i], pet_types[i])
 
-	# Guarantee at least one pet has a koala rider
+	# Guarantee at least one pet has a koala rider before building visuals
 	var any_koala = false
 	for pid in game_manager.pets.keys():
 		if game_manager.pets[pid].get("has_koala", false):
 			any_koala = true
 			break
 	if not any_koala:
-		# Give a random starting pet a koala
 		var all_ids = game_manager.pets.keys()
 		var lucky_id = all_ids[randi() % all_ids.size()]
 		game_manager.pets[lucky_id]["has_koala"] = true
+
+	# Now spawn visuals — Pet._ready() will see correct has_koala data
+	for pid in game_manager.pets.keys():
+		_spawn_pet_in_world(pid)
 
 	_refresh_pet_list()
 

--- a/scripts/Pet.gd
+++ b/scripts/Pet.gd
@@ -5,7 +5,7 @@ class_name Pet
 
 var pet_id: int
 var pet_name: String
-var pet_type: String  # "unicorn", "pegasus", "dragon", "alicorn", "dogocorn", "catocorn"
+var pet_type: String  # "unicorn", "pegasus", "dragon", "alicorn", "dogicorn", "caticorn"
 
 var _game_manager
 var _audio_manager
@@ -64,11 +64,11 @@ func _build_body():
 	var sphere_mesh = SphereMesh.new()
 
 	match pet_type:
-		"dogocorn":
+		"dogicorn":
 			sphere_mesh.radius = 0.5
 			sphere_mesh.height = 0.9
 			_body_mesh.scale = Vector3(1.1, 0.85, 1.3)  # stocky
-		"catocorn":
+		"caticorn":
 			sphere_mesh.radius = 0.4
 			sphere_mesh.height = 0.75
 			_body_mesh.scale = Vector3(0.9, 0.95, 1.4)  # sleek and long
@@ -90,11 +90,11 @@ func _build_head():
 	var head = SphereMesh.new()
 
 	match pet_type:
-		"dogocorn":
+		"dogicorn":
 			head.radius = 0.28
 			head.height = 0.55
 			_head_mesh.position = Vector3(0, 0.3, -0.4)
-		"catocorn":
+		"caticorn":
 			head.radius = 0.22
 			head.height = 0.44
 			_head_mesh.position = Vector3(0, 0.38, -0.38)
@@ -122,10 +122,10 @@ func _build_head():
 	var eye_z = -0.55
 	var eye_y = 0.38
 	match pet_type:
-		"dogocorn":
+		"dogicorn":
 			eye_z = -0.58
 			eye_y = 0.35
-		"catocorn":
+		"caticorn":
 			eye_z = -0.52
 			eye_y = 0.4
 
@@ -152,14 +152,14 @@ func _build_legs():
 
 	# Adjust leg positions for different body shapes
 	match pet_type:
-		"dogocorn":
+		"dogicorn":
 			leg_positions = [
 				Vector3(-0.25, -0.42, -0.25),
 				Vector3(0.25, -0.42, -0.25),
 				Vector3(-0.25, -0.42, 0.25),
 				Vector3(0.25, -0.42, 0.25),
 			]
-		"catocorn":
+		"caticorn":
 			leg_positions = [
 				Vector3(-0.18, -0.45, -0.25),
 				Vector3(0.18, -0.45, -0.25),
@@ -192,12 +192,12 @@ func _build_horn():
 	var cone_mesh = CylinderMesh.new()
 
 	match pet_type:
-		"dogocorn":
+		"dogicorn":
 			cone_mesh.top_radius = 0.0
 			cone_mesh.bottom_radius = 0.07
 			cone_mesh.height = 0.35
 			horn.position = Vector3(0, 0.55, -0.4)
-		"catocorn":
+		"caticorn":
 			cone_mesh.top_radius = 0.0
 			cone_mesh.bottom_radius = 0.06
 			cone_mesh.height = 0.3
@@ -241,9 +241,9 @@ func _build_type_features():
 			_build_alicorn_features()
 			_build_mane([Color(0.8, 0.6, 0.95)])
 			_build_equine_tail([Color(0.8, 0.6, 0.95)])
-		"dogocorn":
+		"dogicorn":
 			_build_dog_features()
-		"catocorn":
+		"caticorn":
 			_build_cat_features()
 
 func _build_mane(colors: Array):
@@ -599,67 +599,80 @@ func _build_cat_features():
 
 func _build_koala():
 	var koala_root = Node3D.new()
-	koala_root.position = Vector3(0, 0.45, 0.05)
+	koala_root.position = Vector3(0, 0.55, 0.05)
 	koala_root.name = "Koala"
 
-	# Body
+	# Body — larger and warm brown
 	var body = MeshInstance3D.new()
 	var body_mesh = SphereMesh.new()
-	body_mesh.radius = 0.12
-	body_mesh.height = 0.2
+	body_mesh.radius = 0.18
+	body_mesh.height = 0.3
 	body.mesh = body_mesh
 	var bmat = StandardMaterial3D.new()
-	bmat.albedo_color = Color(0.55, 0.55, 0.55)
+	bmat.albedo_color = Color(0.5, 0.4, 0.3)  # warm brown
 	body.material_override = bmat
 	koala_root.add_child(body)
 
-	# Head
+	# Head — lighter tan
 	var head = MeshInstance3D.new()
 	var head_mesh = SphereMesh.new()
-	head_mesh.radius = 0.09
-	head_mesh.height = 0.16
+	head_mesh.radius = 0.14
+	head_mesh.height = 0.24
 	head.mesh = head_mesh
-	head.position = Vector3(0, 0.18, -0.05)
+	head.position = Vector3(0, 0.25, -0.06)
 	var hmat = StandardMaterial3D.new()
-	hmat.albedo_color = Color(0.6, 0.6, 0.6)
+	hmat.albedo_color = Color(0.65, 0.55, 0.4)  # lighter tan
 	head.material_override = hmat
 	koala_root.add_child(head)
 
-	# Round fluffy ears
+	# Round fluffy ears — distinctive dark with pink inner
 	for side in [-1.0, 1.0]:
+		# Outer ear (dark brown)
 		var ear = MeshInstance3D.new()
 		var ear_mesh = SphereMesh.new()
-		ear_mesh.radius = 0.055
-		ear_mesh.height = 0.065
+		ear_mesh.radius = 0.09
+		ear_mesh.height = 0.1
 		ear.mesh = ear_mesh
-		ear.position = Vector3(side * 0.08, 0.25, -0.05)
+		ear.position = Vector3(side * 0.12, 0.35, -0.06)
 		var emat = StandardMaterial3D.new()
-		emat.albedo_color = Color(0.4, 0.4, 0.4)
+		emat.albedo_color = Color(0.35, 0.25, 0.18)
 		ear.material_override = emat
 		koala_root.add_child(ear)
+		# Inner ear (pink)
+		var inner_ear = MeshInstance3D.new()
+		var ie_mesh = SphereMesh.new()
+		ie_mesh.radius = 0.05
+		ie_mesh.height = 0.06
+		inner_ear.mesh = ie_mesh
+		inner_ear.position = Vector3(side * 0.12, 0.35, -0.1)
+		var ie_mat = StandardMaterial3D.new()
+		ie_mat.albedo_color = Color(0.9, 0.6, 0.6)  # pink
+		inner_ear.material_override = ie_mat
+		koala_root.add_child(inner_ear)
 
-	# Eyes
+	# Eyes — shiny black
 	for side in [-1.0, 1.0]:
 		var eye = MeshInstance3D.new()
 		var eye_mesh = SphereMesh.new()
-		eye_mesh.radius = 0.02
-		eye_mesh.height = 0.03
+		eye_mesh.radius = 0.035
+		eye_mesh.height = 0.04
 		eye.mesh = eye_mesh
-		eye.position = Vector3(side * 0.04, 0.2, -0.12)
+		eye.position = Vector3(side * 0.06, 0.28, -0.18)
 		var eyemat = StandardMaterial3D.new()
-		eyemat.albedo_color = Color.BLACK
+		eyemat.albedo_color = Color(0.05, 0.05, 0.05)
+		eyemat.metallic = 0.3
 		eye.material_override = eyemat
 		koala_root.add_child(eye)
 
-	# Nose
+	# Big round nose — signature koala feature
 	var nose = MeshInstance3D.new()
 	var nose_mesh = SphereMesh.new()
-	nose_mesh.radius = 0.025
-	nose_mesh.height = 0.03
+	nose_mesh.radius = 0.045
+	nose_mesh.height = 0.04
 	nose.mesh = nose_mesh
-	nose.position = Vector3(0, 0.17, -0.13)
+	nose.position = Vector3(0, 0.22, -0.2)
 	var nmat = StandardMaterial3D.new()
-	nmat.albedo_color = Color(0.15, 0.1, 0.1)
+	nmat.albedo_color = Color(0.1, 0.08, 0.08)
 	nose.material_override = nmat
 	koala_root.add_child(nose)
 
@@ -786,11 +799,11 @@ func _process(delta: float):
 			tail_node.rotation.y = sin(_bob_time * 1.5) * 0.3
 
 	# Dog tail wag (fast side-to-side)
-	if pet_type == "dogocorn" and _tail_node:
+	if pet_type == "dogicorn" and _tail_node:
 		_tail_node.rotation.y = sin(_bob_time * 8.0) * 0.4
 
 	# Cat tail swish (slow, elegant)
-	if pet_type == "catocorn" and _tail_node:
+	if pet_type == "caticorn" and _tail_node:
 		_tail_node.rotation.y = sin(_bob_time * 1.2) * 0.5
 		_tail_node.rotation.x = sin(_bob_time * 0.8) * 0.1
 
@@ -912,9 +925,9 @@ func _get_pet_color() -> Color:
 			return Color(0.0, 0.6, 0.0)
 		"alicorn":
 			return Color(0.6, 0.2, 0.8)
-		"dogocorn":
+		"dogicorn":
 			return Color(0.72, 0.53, 0.34)
-		"catocorn":
+		"caticorn":
 			return Color(0.95, 0.6, 0.2)
 		_:
 			return Color.WHITE

--- a/scripts/SaveManager.gd
+++ b/scripts/SaveManager.gd
@@ -140,8 +140,14 @@ func import_pets_from_csv() -> Dictionary:
 		var pet_name = str(cols[1]).replace(";", ",")  # reverse the comma escaping
 		var pet_type = str(cols[2])
 
+		# Map old type names to new names
+		if pet_type == "dogocorn":
+			pet_type = "dogicorn"
+		elif pet_type == "catocorn":
+			pet_type = "caticorn"
+
 		# Validate pet type
-		if pet_type not in ["unicorn", "pegasus", "dragon", "alicorn", "dogocorn", "catocorn"]:
+		if pet_type not in ["unicorn", "pegasus", "dragon", "alicorn", "dogicorn", "caticorn"]:
 			continue
 
 		# CSV columns: pet_id(0),name(1),type(2),level(3),xp(4),


### PR DESCRIPTION
## Summary
- Fix koala rider guarantee bug — data is now set before Pet visuals are built, so the guaranteed koala actually renders
- Increase koala rider size (~50% larger) with warm brown/tan coloring and distinctive pink inner ears for better visibility
- Rename dogocorn → dogicorn and catocorn → caticorn across all 6 affected files
- Add backward compatibility in both JSON loader and CSV importer to map old type names automatically

## Test plan
- [ ] New game: verify at least one starting pet has a visible koala rider
- [ ] Koala rider is clearly visible on pet backs (brown body, tan head, pink ears)
- [ ] Pet types display as "dogicorn" and "caticorn" everywhere (hub, island, profile)
- [ ] Load old save with "dogocorn"/"catocorn" types — verify they convert to new names
- [ ] CSV import with old type names maps correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)