### PR TITLE
fix: clarify spacebar role in all mini-games (Closes #23)

### DIFF
--- a/scripts/MathGame.gd
+++ b/scripts/MathGame.gd
@@ -341,7 +341,7 @@ func _end_game():
 	# Clear pending game — player completed it
 	game_manager.pending_game = ""
 
-	result_text += "\n\nPress ESC to return to Hub"
+	result_text += "\n\nSPACE: play again | ESC: return to Hub"
 	_result_label.text = result_text
 	_result_label.visible = true
 
@@ -376,6 +376,8 @@ func _input(event):
 			return
 
 		if not _game_active:
+			if event.keycode == KEY_SPACE:
+				get_tree().reload_current_scene()
 			return
 
 		if event.keycode == KEY_UP:

--- a/scripts/MemoryGame.gd
+++ b/scripts/MemoryGame.gd
@@ -288,7 +288,7 @@ func _game_won():
 	var msg = "You matched them all! +%d bonus coins!%s" % [bonus, egg_msg]
 	if leveled_up:
 		msg += " LEVEL UP! Now Level %d: %s" % [_level, LEVEL_NAMES[_level]]
-	msg += " ESC to exit."
+	msg += " SPACE: play again | ESC: exit"
 	_info_label.text = msg
 	_update_status()
 	can_flip = false
@@ -302,8 +302,10 @@ func _input(event):
 			get_tree().change_scene_to_file("res://scenes/Main.tscn")
 			return
 
-		# After winning, no replay from within — just ESC back
+		# After winning, SPACE to play again
 		if matched_pairs >= total_pairs:
+			if event.keycode == KEY_SPACE:
+				get_tree().reload_current_scene()
 			return
 
 		if event.keycode == KEY_UP:

--- a/scripts/MiniGame.gd
+++ b/scripts/MiniGame.gd
@@ -307,7 +307,7 @@ func _end_game():
 	# Clear pending game — player completed it
 	game_manager.pending_game = ""
 
-	result_text += "\n\nPress ESC to return to Hub"
+	result_text += "\n\nSPACE: play again | ESC: return to Hub"
 	_result_label.text = result_text
 	_result_label.visible = true
 
@@ -325,4 +325,9 @@ func _input(event):
 	if event is InputEventKey and event.pressed:
 		if event.keycode == KEY_ESCAPE or event.keycode == KEY_B:
 			_go_back()
+			return
+
+		# Play again after game ends
+		if not _game_active and event.keycode == KEY_SPACE:
+			get_tree().reload_current_scene()
 			return

--- a/scripts/SpellingGame.gd
+++ b/scripts/SpellingGame.gd
@@ -416,7 +416,7 @@ func _end_game():
 	# Clear pending game — player completed it
 	game_manager.pending_game = ""
 
-	result_text += "\n\nPress ESC to return to Hub"
+	result_text += "\n\nSPACE: play again | ESC: return to Hub"
 	_result_label.text = result_text
 	_result_label.visible = true
 
@@ -450,7 +450,12 @@ func _input(event):
 				save_manager.save_game()
 			return
 
-		if not _game_active or _waiting_next:
+		if not _game_active:
+			if event.keycode == KEY_SPACE:
+				get_tree().reload_current_scene()
+			return
+
+		if _waiting_next:
 			return
 
 		if event.keycode == KEY_UP:

--- a/scripts/SudokuGame.gd
+++ b/scripts/SudokuGame.gd
@@ -111,10 +111,13 @@ func _build_ui():
 func _update_labels():
 	_level_label.text = "Level %d: %s" % [_level, LEVEL_NAMES[_level]]
 	_status_label.text = "Puzzles: %d | Coins: +%d | Hints: %d" % [_puzzles_completed, _coins_earned, _hints_used]
-	if _grid_size == 3:
-		_info_label.text = "Arrows: move | 1-3: place | Backspace: clear | H: hint | SPACE: next | ESC: back"
+	if _game_active:
+		if _grid_size == 3:
+			_info_label.text = "Arrows: move | 1-3: place | Backspace: clear | H: hint | ESC: back"
+		else:
+			_info_label.text = "Arrows: move | 1-4: place | Backspace: clear | H: hint | ESC: back"
 	else:
-		_info_label.text = "Arrows: move | 1-4: place | Backspace: clear | H: hint | SPACE: next | ESC: back"
+		_info_label.text = "SPACE: next puzzle | ESC: exit"
 
 func _get_level_config() -> Dictionary:
 	match _level:


### PR DESCRIPTION
## Summary
- **SudokuGame**: Instructions are now context-aware — "SPACE: next" only appears after puzzle completion, not during active gameplay where it did nothing
- **All 5 mini-games** (Sudoku, Memory, Math, Spelling, Treat Catch): Consistent end-of-game messaging with "SPACE: play again | ESC: exit"
- **All 5 mini-games**: SPACE now replays the game after completion via `reload_current_scene()`
- Previously only Sudoku had SPACE replay; other games only offered ESC to exit

## Test plan
- [ ] Sudoku: verify instructions show controls WITHOUT "SPACE: next" during active play
- [ ] Sudoku: verify "SPACE: next puzzle | ESC: exit" appears after solving
- [ ] Sudoku: verify SPACE starts a new puzzle after completion
- [ ] Treat Catch: verify "SPACE: play again | ESC: return to Hub" after game over
- [ ] Treat Catch: verify SPACE restarts the game
- [ ] Math Game: verify SPACE replays after time's up
- [ ] Spelling Game: verify SPACE replays after time's up
- [ ] Memory Game: verify SPACE replays after matching all pairs

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)